### PR TITLE
Ability to set a path to scan

### DIFF
--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -62,7 +62,9 @@ namespace ServiceComposer.AspNetCore
     public class static ServiceCollectionExtensions
     {
         public static void AddViewModelComposition(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public static void AddViewModelComposition(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string compositionsPath) { }
         public static void AddViewModelComposition(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<ServiceComposer.AspNetCore.ViewModelCompositionOptions> config) { }
+        public static void AddViewModelComposition(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string compositionsPath, System.Action<ServiceComposer.AspNetCore.ViewModelCompositionOptions> config) { }
     }
     public class ViewModelCompositionOptions
     {

--- a/src/ServiceComposer.AspNetCore.Tests/When_assembly_scanning.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_assembly_scanning.cs
@@ -45,10 +45,16 @@ namespace ServiceComposer.AspNetCore.Tests
         }
 
         [Fact]
+        public void Without_any_path_to_scan_argumentnullexception_is_thrown()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AssemblyScanner(null));
+        }
+
+        [Fact]
         public void Without_any_filter_should_return_assemblies()
         {
             //arrange
-            var scanner = new AssemblyScanner();
+            var scanner = new AssemblyScanner(AppContext.BaseDirectory);
 
             //act
             var assemblies = scanner.Scan();
@@ -60,7 +66,7 @@ namespace ServiceComposer.AspNetCore.Tests
         public void With_exclude_all_filter_should_return_no_assemblies()
         {
             //arrange
-            var scanner = new AssemblyScanner();
+            var scanner = new AssemblyScanner(AppContext.BaseDirectory);
             scanner.AddAssemblyFilter(assemblyFullPath => AssemblyScanner.FilterResults.Exclude);
             //act
             var assemblies = scanner.Scan();
@@ -73,7 +79,7 @@ namespace ServiceComposer.AspNetCore.Tests
         {
             //arrange
             var currentAssemblyName = "ServiceComposer.AspNetCore.Tests.dll";
-            var scanner = new AssemblyScanner();
+            var scanner = new AssemblyScanner(AppContext.BaseDirectory);
             scanner.AddAssemblyFilter(assemblyFullPath =>
             {
                 return assemblyFullPath.EndsWith(currentAssemblyName)

--- a/src/ServiceComposer.AspNetCore/AssemblyScanner.cs
+++ b/src/ServiceComposer.AspNetCore/AssemblyScanner.cs
@@ -8,6 +8,8 @@ namespace ServiceComposer.AspNetCore
 {
     public class AssemblyScanner
     {
+        private readonly string pathToScan;
+
         public enum FilterResults
         {
             Exclude,
@@ -20,9 +22,14 @@ namespace ServiceComposer.AspNetCore
             "*.exe"
         };
 
-        internal AssemblyScanner()
+        internal AssemblyScanner(string pathToScan)
         {
+            if (string.IsNullOrWhiteSpace(pathToScan))
+            {
+                throw new ArgumentNullException(pathToScan);
+            }
 
+            this.pathToScan = pathToScan;
         }
 
         public SearchOption DirectorySearchOptions { get; set; } = SearchOption.TopDirectoryOnly;
@@ -50,7 +57,7 @@ namespace ServiceComposer.AspNetCore
             foreach (var patternToUse in assemblySearchPatternsToUse)
             {
                 var assembliesFullPaths = Directory
-                    .GetFiles(AppContext.BaseDirectory, patternToUse, DirectorySearchOptions)
+                    .GetFiles(this.pathToScan, patternToUse, DirectorySearchOptions)
                     .Where(fullPathsFilter);
 
                 foreach (var assemblyFullPath in assembliesFullPaths)

--- a/src/ServiceComposer.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/ServiceComposer.AspNetCore/ServiceCollectionExtensions.cs
@@ -7,12 +7,22 @@ namespace ServiceComposer.AspNetCore
     {
         public static void AddViewModelComposition(this IServiceCollection services)
         {
-            AddViewModelComposition(services, null);
+            AddViewModelComposition(services, AppContext.BaseDirectory, null);
+        }
+
+        public static void AddViewModelComposition(this IServiceCollection services, string compositionsPath)
+        {
+            AddViewModelComposition(services, compositionsPath, null);
         }
 
         public static void AddViewModelComposition(this IServiceCollection services, Action<ViewModelCompositionOptions> config)
         {
-            var options = new ViewModelCompositionOptions(services);
+            AddViewModelComposition(services, AppContext.BaseDirectory, config);
+        }
+
+        public static void AddViewModelComposition(this IServiceCollection services, string compositionsPath, Action<ViewModelCompositionOptions> config)
+        {
+            var options = new ViewModelCompositionOptions(services, compositionsPath);
             config?.Invoke(options);
 
             options.InitializeServiceCollection();

--- a/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
+++ b/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
@@ -29,6 +29,12 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions">
+      <HintPath>..\..\..\..\..\Users\JoeyChömpff\.nuget\packages\microsoft.extensions.configuration.abstractions\2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
   <Target Name="AppVeyorPullRequestsTarget" AfterTargets="MinVer" Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''">
     <PropertyGroup>
       <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(APPVEYOR_PULL_REQUEST_NUMBER).build-id.$(APPVEYOR_BUILD_ID).$(MinVerPreRelease)</PackageVersion>

--- a/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
+++ b/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
@@ -8,10 +8,11 @@ namespace ServiceComposer.AspNetCore
 {
     public class ViewModelCompositionOptions
     {
-        internal ViewModelCompositionOptions(IServiceCollection services)
+        internal ViewModelCompositionOptions(IServiceCollection services, string compostionsPath)
         {
             Services = services;
-            AssemblyScanner = new AssemblyScanner();
+
+            AssemblyScanner = new AssemblyScanner(compostionsPath);
         }
 
         List<(Func<Type, bool>, Action<IEnumerable<Type>>)> typesRegistrationHandlers = new List<(Func<Type, bool>, Action<IEnumerable<Type>>)>();


### PR DESCRIPTION
If you scan a specific directory than it's easier to identify(and delete) your composition assemblies