### PR TITLE
Fix: Application startup fails if ASPNETCORE_ENVIRONMENT is set to Development

### DIFF
--- a/src/ServiceComposer.AspNetCore.Endpoints.Tests/ServiceComposer.AspNetCore.Endpoints.Tests.csproj
+++ b/src/ServiceComposer.AspNetCore.Endpoints.Tests/ServiceComposer.AspNetCore.Endpoints.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="FakeItEasy" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="PublicApiGenerator" Version="10.1.2" />
-    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="1.1.0" />
+    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="1.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ServiceComposer.AspNetCore.Endpoints.Tests/When_validating_container_configuration.cs
+++ b/src/ServiceComposer.AspNetCore.Endpoints.Tests/When_validating_container_configuration.cs
@@ -29,7 +29,7 @@ namespace ServiceComposer.AspNetCore.Endpoints.Tests
         public async Task Startup_should_not_fail()
         {
             // Arrange
-            var client = new SelfContainedWebApplicationFactoryWithHost<Dummy>
+            using var webApp = new SelfContainedWebApplicationFactoryWithHost<Dummy>
             (
                 configureServices: services =>
                 {
@@ -55,7 +55,9 @@ namespace ServiceComposer.AspNetCore.Endpoints.Tests
                         options.ValidateOnBuild = true;
                     });
                 }
-            }.CreateClient();
+            };
+
+            var client = webApp.CreateClient();
 
             // Act
             var response = await client.GetAsync("/empty-response/1");

--- a/src/ServiceComposer.AspNetCore.Endpoints.Tests/When_validating_container_configuration.cs
+++ b/src/ServiceComposer.AspNetCore.Endpoints.Tests/When_validating_container_configuration.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json.Linq;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Endpoints.Tests
+{
+    public class When_validating_container_configuration
+    {
+        class EmptyResponseHandler : ICompositionRequestsHandler
+        {
+            [HttpGet("/empty-response/{id}")]
+            public Task Handle(HttpRequest request)
+            {
+                var vm = request.GetComposedResponseModel();
+                var ctx = request.GetCompositionContext();
+                vm.RequestId = ctx.RequestId;
+
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task Startup_should_not_fail()
+        {
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithHost<Dummy>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.RegisterCompositionHandler<EmptyResponseHandler>();
+                    });
+                    services.AddRouting();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder => builder.MapCompositionHandlers());
+                }
+            )
+            {
+                HostBuilderCustomization = builder =>
+                {
+                    builder.UseDefaultServiceProvider(options =>
+                    {
+                        options.ValidateScopes = true;
+                        options.ValidateOnBuild = true;
+                    });
+                }
+            }.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/empty-response/1");
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            var contentString = await response.Content.ReadAsStringAsync();
+            dynamic body = JObject.Parse(contentString);
+            Assert.NotNull(body.requestId);
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore/ModelBinding/HttpRequestModelBinderExtension.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/HttpRequestModelBinderExtension.cs
@@ -1,6 +1,5 @@
 ﻿#if NET5_0 || NETCOREAPP3_1
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,20 +11,7 @@ namespace ServiceComposer.AspNetCore
         public static Task<T> Bind<T>(this HttpRequest request) where T : new()
         {
             var context = request.HttpContext;
-            RequestModelBinder binder;
-            try
-            {
-                binder = context.RequestServices.GetRequiredService<RequestModelBinder>();
-            }
-            catch (InvalidOperationException e)
-            {
-                throw new InvalidOperationException("Unable to resolve one of the services required to support model binding. " +
-                                                    "Make sure the application is configured to use MVC services by calling either " +
-                                                    $"services.{nameof(MvcServiceCollectionExtensions.AddControllers)}(), or " +
-                                                    $"services.{nameof(MvcServiceCollectionExtensions.AddControllersWithViews)}(), or " +
-                                                    $"services.{nameof(MvcServiceCollectionExtensions.AddMvc)}(), or " +
-                                                    $"services.{nameof(MvcServiceCollectionExtensions.AddRazorPages)}().", e);
-            }
+            var binder = context.RequestServices.GetRequiredService<RequestModelBinder>();
 
             return binder.Bind<T>(request);
         }


### PR DESCRIPTION
Fix #297 

## Change the way the `RequestModelBinder` is registered

from:

```csharp
Services.AddSingleton<RequestModelBinder>();
```

to

```csharp
Services.AddSingleton(container =>
{
    var modelBinderFactory = container.GetService<IModelBinderFactory>();
    var modelMetadataProvider = container.GetService<IModelMetadataProvider>();
    var mvcOptions = container.GetService<IOptions<MvcOptions>>();

    //if any is null throw

    return new RequestModelBinder(modelBinderFactory, modelMetadataProvider, mvcOptions);
});
```

making so that the startup checks cannot validate that logic. With a `launchSettings.json` like the following:

```
{
  "profiles": {
    "CompositionGateway": {
      "commandName": "Project",
      "environmentVariables": {
        "ASPNETCORE_ENVIRONMENT": "Development"
      },
      "applicationUrl": "http://localhost:4457"
    }
  }
}
```

And a startup as simple as:

```csharp
public class Startup
{
    public void ConfigureServices(IServiceCollection services)
    {
        services.AddRouting();
        services.AddViewModelComposition();
    }

    public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
    {
        app.UseRouting();
        app.UseEndpoints(builder => builder.MapCompositionHandlers());
    }
}
```

the application doesn't start. The problem is that when `ASPNETCORE_ENVIRONMENT` is set to `Development` the code that builds the service provider instance performs additional checks, one being that all registered components can be successfully resolved. We always register the `RequestModelBinder` class, it has dependencies on MVC services that are available only;y if the user configures them (e.g., by calling `services.AddControllers()`). If the dependencies are not registered the container creation process throws.

The same problem can be reproduced by manually setting the ServiceProviderOptions when building the Host, e.g.

```
hostBuilder.UseDefaultServiceProvider(options =>
{
   options.ValidateOnBuild = true;
});
```

## PoA

- [x] PR description
- [x] Apply labels as appropriate
- [x] tests
- ~documentation~
