### PR TITLE
Extend MapCompositionHandlers() to return IEndpointConventionBuilder

### DIFF
--- a/src/ServiceComposer.AspNetCore.Endpoints.Tests/When_adding_endpoint_builder_customizations.cs
+++ b/src/ServiceComposer.AspNetCore.Endpoints.Tests/When_adding_endpoint_builder_customizations.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Endpoints.Tests
+{
+    public class When_adding_endpoint_builder_customizations
+    {
+        class TestGetIntegerHandler : ICompositionRequestsHandler
+        {
+            [HttpGet("/sample/{id}")]
+            public Task Handle(HttpRequest request)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task Convention_is_invoked_as_expected()
+        {
+            var invoked = false;
+            Action<EndpointBuilder> convention = builder => invoked = true;
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<Dummy>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.RegisterCompositionHandler<TestGetIntegerHandler>();
+                        options.ResponseSerialization.UseOutputFormatters = true;
+                    });
+                    services.AddRouting();
+                    services.AddControllers()
+                        .AddNewtonsoftJson();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder =>
+                    {
+                        var conventionBuilder = builder.MapCompositionHandlers();
+                        conventionBuilder.Add(convention);
+                    });
+                }
+            ).CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/sample/1");
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.True(invoked);
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -52,10 +52,10 @@ namespace ServiceComposer.AspNetCore
     }
     public static class EndpointsExtensions
     {
-        public static void MapCompositionHandlers(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints) { }
+        public static Microsoft.AspNetCore.Builder.IEndpointConventionBuilder MapCompositionHandlers(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints) { }
         [System.Obsolete("To enable write support use the EnableWriteSupport() method on the ViewModelCompo" +
             "sitionOptions. This method will be treated as an error in v2 and removed in v3.")]
-        public static void MapCompositionHandlers(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, bool enableWriteSupport) { }
+        public static Microsoft.AspNetCore.Builder.IEndpointConventionBuilder MapCompositionHandlers(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, bool enableWriteSupport) { }
     }
     [System.Obsolete("EventHandler<TEvent> is obsoleted and will be treated as an error starting v2 and" +
         " removed in v3. Use attribute routing based composition, and CompositionEventHan" +

--- a/src/ServiceComposer.AspNetCore/EndpointsExtensions.cs
+++ b/src/ServiceComposer.AspNetCore/EndpointsExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -17,16 +18,16 @@ namespace ServiceComposer.AspNetCore
         static readonly Dictionary<string, Type[]> compositionOverControllerGetComponents = new();
         static readonly Dictionary<string, Type[]> compositionOverControllerPostComponents = new();
 
-        public static void MapCompositionHandlers(this IEndpointRouteBuilder endpoints)
+        public static IEndpointConventionBuilder MapCompositionHandlers(this IEndpointRouteBuilder endpoints)
         {
 #pragma warning disable 618
-            MapCompositionHandlers(endpoints, false);
+            return MapCompositionHandlers(endpoints, false);
 #pragma warning restore 618
         }
 
         [Obsolete(
             "To enable write support use the EnableWriteSupport() method on the ViewModelCompositionOptions. This method will be treated as an error in v2 and removed in v3.")]
-        public static void MapCompositionHandlers(this IEndpointRouteBuilder endpoints, bool enableWriteSupport)
+        public static IEndpointConventionBuilder MapCompositionHandlers(this IEndpointRouteBuilder endpoints, bool enableWriteSupport)
         {
             if (endpoints == null)
             {
@@ -81,6 +82,9 @@ namespace ServiceComposer.AspNetCore
                     options.ResponseSerialization.DefaultResponseCasing,
                     options.ResponseSerialization.UseOutputFormatters);
             }
+            
+            var dataSource = endpoints.DataSources.OfType<CompositionEndpointDataSource>().FirstOrDefault();
+            return dataSource;
         }
 
         private static void MapGetComponents(CompositionMetadataRegistry compositionMetadataRegistry,


### PR DESCRIPTION
Extend `MapCompositionHandlers()` to return `IEndpointConventionBuilder` allowing endpoint builders to be customized before the endpoint creation.

## PoA

- [x] PR description
- [x] Apply labels as appropriate
- [x] tests
- ~~documentation~~ not needed, it's just the standard practice for endpoints routing extensions methods
