### PR TITLE
Expose IConfiguration in ViewModelCompositionOptions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,3 +24,7 @@ By virtue of leveraging ASP.NET Core 3.x Endpoints ServiceComposer automatically
 By default ServiceComposer serializes responses using the Newtonsoft JSON serializer. The built-in serialization support can be configured to seriazlie responses using a camel case or pascal case approach on a per request basis by adding to the request an `Accept-Casing` custom HTTP header. For more information refer to the [response serialization casing](response-serialization-casing.md) section. Or it's possible to take full control over the [response serialization settings on a case-by-case](custom-json-response-serialization-settings.md) by suppliying at configuration time a customization function.
 
 Starting with version 1.9.0, regular MVC Output Formatters can be used to serialize the response model, and honor the `Accept` HTTP header set by clients. When using output formatters the serialization casing is controlled by the formatter configuration and not by ServiceComposer. For more information on using output formatters refers to the [output formatters serialization section](output-formatters-serialization.md).
+
+## Customizing ViewModel Composition options from dependent assemblies
+
+It's possible to access and [customize ViewModel Composition options](options-customizations.md) at application start-up by defining types implmenting the `IViewModelCompositionOptionsCustomization` interface.

--- a/docs/options-customizations.md
+++ b/docs/options-customizations.md
@@ -1,0 +1,7 @@
+# Customizing ViewModel Composition options from dependent assemblies
+
+Assemblies containing types participating in the composition process can customize the current application `ViewModelCompositionOptions` by defining a type that implements the `IViewModelCompositionOptionsCustomization` interface. At runtime, when the application starts, types implementing the `IViewModelCompositionOptionsCustomization` will be instantiated and the `Customize` method will be invoked.
+
+> Note: Types implementing `IViewModelCompositionOptionsCustomization` are not managed by IoC container. Dependency injection is not available.
+
+`ViewModelCompositionOptions` offers the ability to access the application `IConfiguration` insance. By default the `ViewModelCompositionOptions.Configuration` property is null. If accessed it throws an `ArgumentException`. To enable configuration support, pass the `IConfiguration` instance when configuring ServiceComposer via the  `AddViewModelComposition` extension method.

--- a/src/ServiceComposer.AspNetCore.Endpoints.Tests/Utils/IsNestedTypeOfExtension.cs
+++ b/src/ServiceComposer.AspNetCore.Endpoints.Tests/Utils/IsNestedTypeOfExtension.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ServiceComposer.AspNetCore.Endpoints.Tests;
+
+public static class IsNestedTypeOfExtension
+{
+    public static bool IsNestedTypeOf<T>(this Type type) where T : class
+    {
+        return type.IsNested
+               && typeof(T).GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public)
+                   .Contains(type);
+    }
+}

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -162,12 +162,13 @@ namespace ServiceComposer.AspNetCore
     }
     public static class ServiceCollectionExtensions
     {
-        public static void AddViewModelComposition(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
-        public static void AddViewModelComposition(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<ServiceComposer.AspNetCore.ViewModelCompositionOptions> config) { }
+        public static void AddViewModelComposition(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration = null) { }
+        public static void AddViewModelComposition(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<ServiceComposer.AspNetCore.ViewModelCompositionOptions> config, Microsoft.Extensions.Configuration.IConfiguration configuration = null) { }
     }
     public class ViewModelCompositionOptions
     {
         public ServiceComposer.AspNetCore.AssemblyScanner AssemblyScanner { get; }
+        public Microsoft.Extensions.Configuration.IConfiguration Configuration { get; }
         public ServiceComposer.AspNetCore.ResponseSerializationOptions ResponseSerialization { get; }
         public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
         public void AddServicesConfigurationHandler(System.Type serviceType, System.Action<System.Type, Microsoft.Extensions.DependencyInjection.IServiceCollection> configurationHandler) { }

--- a/src/ServiceComposer.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/ServiceComposer.AspNetCore/ServiceCollectionExtensions.cs
@@ -1,18 +1,19 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using Microsoft.Extensions.Configuration;
 
 namespace ServiceComposer.AspNetCore
 {
     public static class ServiceCollectionExtensions
     {
-        public static void AddViewModelComposition(this IServiceCollection services)
+        public static void AddViewModelComposition(this IServiceCollection services, IConfiguration configuration = null)
         {
-            AddViewModelComposition(services, null);
+            AddViewModelComposition(services, null, configuration);
         }
 
-        public static void AddViewModelComposition(this IServiceCollection services, Action<ViewModelCompositionOptions> config)
+        public static void AddViewModelComposition(this IServiceCollection services, Action<ViewModelCompositionOptions> config, IConfiguration configuration = null)
         {
-            var options = new ViewModelCompositionOptions(services);
+            var options = new ViewModelCompositionOptions(services, configuration);
             config?.Invoke(options);
 
             options.InitializeServiceCollection();

--- a/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
+++ b/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace ServiceComposer.AspNetCore
@@ -15,9 +16,10 @@ namespace ServiceComposer.AspNetCore
         readonly CompositionMetadataRegistry _compositionMetadataRegistry = new CompositionMetadataRegistry();
         readonly CompositionOverControllersRoutes _compositionOverControllersRoutes = new CompositionOverControllersRoutes();
 
-        internal ViewModelCompositionOptions(IServiceCollection services)
+        internal ViewModelCompositionOptions(IServiceCollection services, IConfiguration configuration = null)
         {
             Services = services;
+            Configuration = configuration;
             AssemblyScanner = new AssemblyScanner();
 
             Services.AddSingleton(this);
@@ -206,6 +208,8 @@ namespace ServiceComposer.AspNetCore
         public AssemblyScanner AssemblyScanner { get; }
 
         public IServiceCollection Services { get; }
+        
+        public IConfiguration Configuration { get; }
 
         public ResponseSerializationOptions ResponseSerialization { get; }
 

--- a/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
+++ b/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
@@ -13,13 +13,14 @@ namespace ServiceComposer.AspNetCore
 {
     public class ViewModelCompositionOptions
     {
+        readonly IConfiguration _configuration;
         readonly CompositionMetadataRegistry _compositionMetadataRegistry = new CompositionMetadataRegistry();
         readonly CompositionOverControllersRoutes _compositionOverControllersRoutes = new CompositionOverControllersRoutes();
 
         internal ViewModelCompositionOptions(IServiceCollection services, IConfiguration configuration = null)
         {
+            _configuration = configuration;
             Services = services;
-            Configuration = configuration;
             AssemblyScanner = new AssemblyScanner();
 
             Services.AddSingleton(this);
@@ -208,8 +209,21 @@ namespace ServiceComposer.AspNetCore
         public AssemblyScanner AssemblyScanner { get; }
 
         public IServiceCollection Services { get; }
-        
-        public IConfiguration Configuration { get; }
+
+        public IConfiguration Configuration
+        {
+            get
+            {
+                if (_configuration is null)
+                {
+                    throw new ArgumentException("No configuration instance has been set. " +
+                                                "To access the application configuration call the " +
+                                                "AddViewModelComposition overload te accepts an " +
+                                                "IConfiguration instance.");
+                }
+                return _configuration;
+            }
+        }
 
         public ResponseSerializationOptions ResponseSerialization { get; }
 

--- a/src/TestClassLibraryWithHandlers/FakeConfig.cs
+++ b/src/TestClassLibraryWithHandlers/FakeConfig.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace TestClassLibraryWithHandlers;
+
+public class FakeConfig : IConfiguration
+{
+    public IEnumerable<IConfigurationSection> GetChildren()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public IChangeToken GetReloadToken()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public IConfigurationSection GetSection(string key)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public string this[string key]
+    {
+        get => throw new System.NotImplementedException();
+        set => throw new System.NotImplementedException();
+    }
+}


### PR DESCRIPTION
The `ViewModelCompositionOptions` exposes a `IConfiguration` Configuration property to allow classes implementing `IViewModelCompositionOptionsCustomization` to access the current configuration.

By default the Configuration property is `null` and if accessed throws an `ArgumentException`. To set the configuration to use, pass the `IConfiguration` instance to `AddViewModelComposition` when configuring the application.

## PoA

- [x] PR description
- [x] Apply labels as appropriate
- [x] tests
- [x] documentation
