### PR TITLE
Support .NET 6 and .NET 7 only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,8 @@ jobs:
         uses: actions/setup-dotnet@v1.9.0
         with:
           dotnet-version: |
+            7.0.x
             6.0.x
-            5.0.x
-            3.1.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Tests

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Imagine an elementary e-commerce web page, where it's needed to display details 
 
 To start using ServiceComposer, follow the outlined steps:
 
-- Create, in an empty or existing solution, a .NET Core 3.x or later empty web application project named `CompositionGateway`.
+- Create, in an empty or existing solution, a .NET 6 or later empty web application project named `CompositionGateway`.
 - Add a package reference to the `ServiceComposer.AspNetCore` NuGet package and configure the `Startup` class as follows:
 
 <!-- snippet: sample-startup -->
@@ -51,7 +51,7 @@ public class Startup
 
 > NOTE: To use a `Startup` class, Generic Host support is required.
 
-- Add a new .NET Core 3.x or later class library project, named `Sales.ViewModelComposition`.
+- Add a new .NET 6 or later class library project, named `Sales.ViewModelComposition`.
 - Add a package reference to the `ServiceComposer.AspNetCore` NuGet package.
 - Add a new class to create a composition request handler.
 - Define the class similar to the following:
@@ -114,7 +114,7 @@ In this brief sample the view model instance returned by `GetComposedResponseMod
 
 ServiceComposer is available for the following platforms:
 
-- ASP.NET Core 3.x, .NET 5, and .NET 6: [documentation is available in the docs folder](docs)
+- ASP.NET Core on .NET 6: [documentation is available in the docs folder](docs)
 
 ## Philosophy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
-# ASP.NET Core 3.x and .NET 5
+# ASP.NET Core on .NET 6
 
-Starting ASP.NET Core 3.x ServiceComposer leverages the new Endpoints support to plugin into the request handling pipeline.
-ServiceComposer can be added to existing or new ASP.NET Core projects, or it can be hosted in .NET Core console applications.
+ServiceComposer leverages the Endpoints support to plugin into the request handling pipeline.
+ServiceComposer can be added to existing or new ASP.NET Core projects, or it can be hosted in .NET console applications.
 
 ## Note about thread safety
 

--- a/src/ServiceComposer.AspNetCore.Endpoints.Tests/ServiceComposer.AspNetCore.Endpoints.Tests.csproj
+++ b/src/ServiceComposer.AspNetCore.Endpoints.Tests/ServiceComposer.AspNetCore.Endpoints.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,20 +15,30 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-	<PackageReference Include="System.Reflection.Metadata" Version="6.0.0" />
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.12" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="6.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="7.0.0" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="MELT" Version="0.7.0" />
     <PackageReference Include="ApprovalTests" Version="5.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="FakeItEasy" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="PublicApiGenerator" Version="10.1.2" />
-    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="1.3.0" />
+    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ServiceComposer.AspNetCore.Endpoints.Tests/ServiceComposer.AspNetCore.Endpoints.Tests.csproj
+++ b/src/ServiceComposer.AspNetCore.Endpoints.Tests/ServiceComposer.AspNetCore.Endpoints.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ServiceComposer.AspNetCore.Endpoints.Tests/When_using_record_types_as_model.cs
+++ b/src/ServiceComposer.AspNetCore.Endpoints.Tests/When_using_record_types_as_model.cs
@@ -1,0 +1,65 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Endpoints.Tests
+{
+    public class When_using_record_types_as_model
+    {
+        class TestGetIntegerHandler : ICompositionRequestsHandler
+        {
+            record Model
+            {
+                [FromRoute]public int id { get; set; }
+            }
+
+            [HttpGet("/sample/{id}")]
+            public async Task Handle(HttpRequest request)
+            {
+                var model = await request.Bind<Model>();
+                var vm = request.GetComposedResponseModel();
+                vm.ANumber = model.id;
+            }
+        }
+
+        [Fact]
+        public async Task Returns_expected_response()
+        {
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<Dummy>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.RegisterCompositionHandler<TestGetIntegerHandler>();
+                    });
+                    services.AddRouting();
+                    services.AddControllers();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder => builder.MapCompositionHandlers());
+                }
+            ).CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/sample/1");
+
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var responseObj = JObject.Parse(responseString);
+
+            Assert.Equal(1, responseObj?.SelectToken("aNumber")?.Value<int>());
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore.Tests/ServiceComposer.AspNetCore.Tests.csproj
+++ b/src/ServiceComposer.AspNetCore.Tests/ServiceComposer.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,11 +10,19 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-	<PackageReference Include="System.Reflection.Metadata" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,7 +30,7 @@
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
-    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="1.3.0" />
+    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ServiceComposer.AspNetCore.Tests/ServiceComposer.AspNetCore.Tests.csproj
+++ b/src/ServiceComposer.AspNetCore.Tests/ServiceComposer.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ServiceComposer.AspNetCore/ModelBinding/RequestModelBinder.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/RequestModelBinder.cs
@@ -39,12 +39,10 @@ namespace ServiceComposer.AspNetCore
             var valueProvider =
                 await CompositeValueProvider.CreateAsync(actionContext, mvcOptions.Value.ValueProviderFactories);
 
-#if NET5_0
             if (modelMetadata.BoundConstructor != null)
             {
                 throw new NotSupportedException("Record type not supported");
             }
-#endif
 
             var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
                 actionContext,

--- a/src/ServiceComposer.AspNetCore/ModelBinding/RequestModelBinder.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/RequestModelBinder.cs
@@ -39,11 +39,6 @@ namespace ServiceComposer.AspNetCore
             var valueProvider =
                 await CompositeValueProvider.CreateAsync(actionContext, mvcOptions.Value.ValueProviderFactories);
 
-            if (modelMetadata.BoundConstructor != null)
-            {
-                throw new NotSupportedException("Record type not supported");
-            }
-
             var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
                 actionContext,
                 valueProvider,

--- a/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
+++ b/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
+++ b/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -29,11 +29,19 @@
   </ItemGroup>
 
   <ItemGroup>
-	<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.1.5, 7.0.0)" />
-	<PackageReference Include="System.Reflection.Metadata" Version="[1.8.1, 7.0.0)" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Newtonsoft.Json" Version="[12.0.3, 14.0.0)" />
     <PackageReference Include="System.ValueTuple" Version="[4.5.0, 5.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="[3.1.5, 7.0.0)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="[1.8.1, 7.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="[7.0.0, 8.0.0)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="[7.0.0, 8.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Snippets/Snippets.csproj
+++ b/src/Snippets/Snippets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/TestClassLibraryWithHandlers/TestClassLibraryWithHandlers.csproj
+++ b/src/TestClassLibraryWithHandlers/TestClassLibraryWithHandlers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fix #372, Fix #343

Remove support for all target frameworks except .NET 6

## PoA

- [x] Add .NET 7 target
- [x] PR description
- [x] Apply labels as appropriate
- [x] tests
  - [x] Verify that record types can be used as model
- [x] documentation
