### PR TITLE
Make case insensitive route matching the default when using composition over controllers

### DIFF
--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -173,8 +173,7 @@ namespace ServiceComposer.AspNetCore
         public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
         public void AddServicesConfigurationHandler(System.Type serviceType, System.Action<System.Type, Microsoft.Extensions.DependencyInjection.IServiceCollection> configurationHandler) { }
         public void AddTypesRegistrationHandler(System.Func<System.Type, bool> typesFilter, System.Action<System.Collections.Generic.IEnumerable<System.Type>> registrationHandler) { }
-        public void EnableCompositionOverControllers() { }
-        public void EnableCompositionOverControllers(bool useCaseInsensitiveRouteMatching) { }
+        public void EnableCompositionOverControllers(bool useCaseInsensitiveRouteMatching = true) { }
         public void EnableWriteSupport() { }
         public void RegisterCompositionEventsSubscriber<T>()
             where T : ServiceComposer.AspNetCore.ISubscribeToCompositionEvents { }

--- a/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
+++ b/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
@@ -50,12 +50,7 @@ namespace ServiceComposer.AspNetCore
 
         internal CompositionOverControllersOptions CompositionOverControllersOptions { get; private set; } = new CompositionOverControllersOptions();
 
-        public void EnableCompositionOverControllers()
-        {
-            EnableCompositionOverControllers(false);
-        }
-
-        public void EnableCompositionOverControllers(bool useCaseInsensitiveRouteMatching)
+        public void EnableCompositionOverControllers(bool useCaseInsensitiveRouteMatching = true)
         {
             CompositionOverControllersOptions.IsEnabled = true;
             CompositionOverControllersOptions.UseCaseInsensitiveRouteMatching = useCaseInsensitiveRouteMatching;


### PR DESCRIPTION
Fix #154 

## PoA

- [x] Apply labels as appropriate
- [x] documentation
