### PR TITLE
Make sure the IEndpointScopedViewModelFactory implementing type is added to components registry

### DIFF
--- a/src/ServiceComposer.AspNetCore.Tests/Get_with_2_handlers_using_endpoint_scoped_view_model_factory.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/Get_with_2_handlers_using_endpoint_scoped_view_model_factory.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;

--- a/src/ServiceComposer.AspNetCore.Tests/Get_with_2_handlers_using_multiple_endpoint_scoped_view_model_factories.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/Get_with_2_handlers_using_multiple_endpoint_scoped_view_model_factories.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json.Linq;
 using ServiceComposer.AspNetCore.Testing;
 using Xunit;
 

--- a/src/ServiceComposer.AspNetCore.Tests/Get_with_no_defined_handlers.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/Get_with_no_defined_handlers.cs
@@ -1,8 +1,6 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceComposer.AspNetCore.Testing;
 using Xunit;

--- a/src/ServiceComposer.AspNetCore.Tests/When_registering_preview_handlers.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_registering_preview_handlers.cs
@@ -2,9 +2,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json.Linq;
 using ServiceComposer.AspNetCore.Testing;
 using Xunit;
 

--- a/src/ServiceComposer.AspNetCore.Tests/When_setting_custom_http_status_code.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_setting_custom_http_status_code.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_assembly_scanner.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_assembly_scanner.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Castle.Core.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_assembly_scanner.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_assembly_scanner.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Castle.Core.Configuration;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceComposer.AspNetCore.Testing;
 using TestClassLibraryWithHandlers;
@@ -263,6 +265,114 @@ namespace ServiceComposer.AspNetCore.Tests
             // Assert
             Assert.NotNull(expectedPreviewHandlers);
             Assert.True(expectedPreviewHandlers.Single().GetType() == typeof(TestPreviewHandler));
+        }
+
+        class TestEndpointScopedViewModelFactory : IEndpointScopedViewModelFactory
+        {
+            [HttpGet("/use-endpoint-scoped-factory/{id}")]
+            public object CreateViewModel(HttpContext httpContext, ICompositionContext compositionContext)
+            {
+                return new TestModel();
+            }
+        }
+        
+        [Fact]
+        public void Endpoint_scoped_factories_are_registered_automatically()
+        {
+            IEnumerable<IEndpointScopedViewModelFactory> expectedEndpointScopedViewModelFactories = null;
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_assembly_scanner>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.TypesFilter = type =>
+                        {
+                            if (type.Assembly.FullName.Contains("TestClassLibraryWithHandlers"))
+                            {
+                                return true;
+                            }
+
+                            if (type == typeof(CustomizationsThatAccessTheConfiguration))
+                            {
+                                return false;
+                            }
+
+                            if (type.IsNestedTypeOf<When_using_assembly_scanner>())
+                            {
+                                return true;
+                            }
+
+                            return false;
+                        };
+                    });
+                    services.AddRouting();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder => builder.MapCompositionHandlers());
+
+                    expectedEndpointScopedViewModelFactories = app.ApplicationServices.GetServices<IEndpointScopedViewModelFactory>();
+                }
+            ).CreateClient();
+
+            // Assert
+            Assert.NotNull(expectedEndpointScopedViewModelFactories);
+            Assert.True(expectedEndpointScopedViewModelFactories.Single().GetType() == typeof(TestEndpointScopedViewModelFactory));
+        }
+        
+        [Fact]
+        public async Task Endpoint_scoped_factories_is_used()
+        {
+            // Arrange
+            var expectedValue = 1;
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_assembly_scanner>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.TypesFilter = type =>
+                        {
+                            if (type.Assembly.FullName.Contains("TestClassLibraryWithHandlers"))
+                            {
+                                return true;
+                            }
+
+                            if (type == typeof(CustomizationsThatAccessTheConfiguration))
+                            {
+                                return false;
+                            }
+
+                            if (type.IsNestedTypeOf<When_using_assembly_scanner>())
+                            {
+                                return true;
+                            }
+
+                            return false;
+                        };
+                    });
+                    services.AddRouting();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder => builder.MapCompositionHandlers());
+                }
+            ).CreateClient();
+
+            // Act
+            var response = await client.GetAsync($"/use-endpoint-scoped-factory/{expectedValue}");
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var responseObj = System.Text.Json.JsonSerializer.Deserialize<TestModel>(responseString);
+            
+            // Assert
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(expectedValue, responseObj.Value);
         }
     }
 }

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_composition_over_controllers_POST_with_2_handlers.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_composition_over_controllers_POST_with_2_handlers.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Dynamic;
+﻿using System.Dynamic;
 using System.IO;
 using System.Net.Http;
 using System.Net.Mime;
@@ -8,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_composition_over_controllers_get_with_2_handlers.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_composition_over_controllers_get_with_2_handlers.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using ServiceComposer.AspNetCore.Testing;

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_multiple_attributes_on_a_handler.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_multiple_attributes_on_a_handler.cs
@@ -1,5 +1,4 @@
-﻿using System.Dynamic;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading;
@@ -8,7 +7,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ServiceComposer.AspNetCore.Testing;
 using Xunit;

--- a/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
+++ b/src/ServiceComposer.AspNetCore/ViewModelCompositionOptions.cs
@@ -156,7 +156,7 @@ namespace ServiceComposer.AspNetCore
                     {
                         foreach (var type in types)
                         {
-                            Services.AddTransient(typeof(IEndpointScopedViewModelFactory), type);
+                            RegisterEndpointScopedViewModelFactory(type);
                         }
                     });
 
@@ -236,6 +236,11 @@ namespace ServiceComposer.AspNetCore
             }
         }
 
+        void RegisterEndpointScopedViewModelFactory(Type viewModelFactoryType)
+        {
+            RegisterCompositionComponents(viewModelFactoryType);
+        }
+        
         public void RegisterEndpointScopedViewModelFactory<T>() where T: IEndpointScopedViewModelFactory
         {
             RegisterCompositionComponents(typeof(T));

--- a/src/TestClassLibraryWithHandlers/TestHandlerUsingEndpointScopedFactory.cs
+++ b/src/TestClassLibraryWithHandlers/TestHandlerUsingEndpointScopedFactory.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using ServiceComposer.AspNetCore;
+
+namespace TestClassLibraryWithHandlers;
+
+public class TestHandlerUsingEndpointScopedFactory : ICompositionRequestsHandler
+{
+    [HttpGet("/use-endpoint-scoped-factory/{id}")]
+    public Task Handle(HttpRequest request)
+    {
+        var vm = request.GetComposedResponseModel<TestModel>();
+        vm.Value = int.Parse(request.RouteValues["id"].ToString());
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/TestClassLibraryWithHandlers/TestModel.cs
+++ b/src/TestClassLibraryWithHandlers/TestModel.cs
@@ -1,0 +1,6 @@
+namespace TestClassLibraryWithHandlers;
+
+public class TestModel
+{
+    public int Value { get; set; }
+}


### PR DESCRIPTION
Fix #520

When the assembly scanner automatically registered types implementing the `IEndpointScopedViewModelFactory` interface, it was not adding them to the components registry that the endpoints builder later uses to determine which types should be bound to which endpoint (primarily based on routing attributes).

This PR makes sure types implementing `IEndpointScopedViewModelFactory` when found by the assembly scanner are correctly registered into the components' registry.

## PoA

- [x] PR description
- [x] Apply labels as appropriate
- [x] tests