### PR TITLE
Manually update Verify.Xunit to 26.3.1

### DIFF
--- a/src/ServiceComposer.AspNetCore.Tests/ServiceComposer.AspNetCore.Tests.csproj
+++ b/src/ServiceComposer.AspNetCore.Tests/ServiceComposer.AspNetCore.Tests.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="MELT" Version="0.9.0" />
-    <PackageReference Include="Verify.Xunit" Version="26.1.6" />
+    <PackageReference Include="Verify.Xunit" Version="26.3.1" />
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />


### PR DESCRIPTION
Due to Dependabot screwing up things: https://github.com/dependabot/dependabot-core/issues/9661