### PR TITLE
Endpoint filters support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ When handling composition requests it possible to leverage the power of ASP.Net 
 
 ### ASP.Net MVC Action results
 
-MVC Action results support allow composition handlers to set custom response results for specific scenarios, like for example, handling bad requests or validation error thoat would nornmally require throwing an exception. For more information on action results refer to the [MVC Action results](action-results.md) section.
+MVC Action results support allow composition handlers to set custom response results for specific scenarios, like for example, handling bad requests or validation error that would normally require throwing an exception. For more information on action results refer to the [MVC Action results](action-results.md) section.
 
 ## Authentication and Authorization
 
@@ -29,10 +29,10 @@ By virtue of leveraging ASP.NET Core 3.x Endpoints ServiceComposer automatically
 
 ## Serialization
 
-By default ServiceComposer serializes responses using the Newtonsoft JSON serializer. The built-in serialization support can be configured to seriazlie responses using a camel case or pascal case approach on a per request basis by adding to the request an `Accept-Casing` custom HTTP header. For more information refer to the [response serialization casing](response-serialization-casing.md) section. Or it's possible to take full control over the [response serialization settings on a case-by-case](custom-json-response-serialization-settings.md) by suppliying at configuration time a customization function.
+By default ServiceComposer serializes responses using the Newtonsoft JSON serializer. The built-in serialization support can be configured to serialize responses using a camel case or pascal case approach on a per request basis by adding to the request an `Accept-Casing` custom HTTP header. For more information refer to the [response serialization casing](response-serialization-casing.md) section. Or it's possible to take full control over the [response serialization settings on a case-by-case](custom-json-response-serialization-settings.md) by supplying at configuration time a customization function.
 
 Starting with version 1.9.0, regular MVC Output Formatters can be used to serialize the response model, and honor the `Accept` HTTP header set by clients. When using output formatters the serialization casing is controlled by the formatter configuration and not by ServiceComposer. For more information on using output formatters refers to the [output formatters serialization section](output-formatters-serialization.md).
 
 ## Customizing ViewModel Composition options from dependent assemblies
 
-It's possible to access and [customize ViewModel Composition options](options-customizations.md) at application start-up by defining types implmenting the `IViewModelCompositionOptionsCustomization` interface.
+It's possible to access and [customize ViewModel Composition options](options-customizations.md) at application start-up by defining types implementing the `IViewModelCompositionOptionsCustomization` interface.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,3 +36,7 @@ Starting with version 1.9.0, regular MVC Output Formatters can be used to serial
 ## Customizing ViewModel Composition options from dependent assemblies
 
 It's possible to access and [customize ViewModel Composition options](options-customizations.md) at application start-up by defining types implementing the `IViewModelCompositionOptionsCustomization` interface.
+
+## Endpoint filters
+
+Endpoint filters allow intercepting all incoming HTTP requests before they reach the composition stage. For more information refer to the [endpoint filters documentation](endpoint-filters.md).

--- a/docs/action-results.md
+++ b/docs/action-results.md
@@ -42,4 +42,5 @@ services.AddViewModelComposition(options =>
 <sup><a href='/src/Snippets/ActionResult/UseSetActionResultHandler.cs#L37-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-action-results-required-config' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Note: ServiceComposer supports only one action result per request. If two or more composition handlers try to set action results, only the frst one will succeed and subsequent requests will be ignored.
+> [!NOTE]
+> ServiceComposer supports only one action result per request. If two or more composition handlers try to set action results, only the frst one will succeed and subsequent requests will be ignored.

--- a/docs/action-results.md
+++ b/docs/action-results.md
@@ -1,6 +1,6 @@
 # ASP.Net MVC Action results
 
-MVC Action results support allow composition handlers to set custom response results for specific scenarios, like for example, handling bad requests or validation error thoat would nornmally require throwing an exception. Setting a custom action result is done by using the `SetActionResult()` `HttpRequest` extension method:
+MVC Action results support allow composition handlers to set custom response results for specific scenarios, like for example, handling bad requests or validation error that would normally require throwing an exception. Setting a custom action result is done by using the `SetActionResult()` `HttpRequest` extension method:
 
 <!-- snippet: action-results -->
 <a id='snippet-action-results'></a>

--- a/docs/action-results.md
+++ b/docs/action-results.md
@@ -43,4 +43,4 @@ services.AddViewModelComposition(options =>
 <!-- endSnippet -->
 
 > [!NOTE]
-> ServiceComposer supports only one action result per request. If two or more composition handlers try to set action results, only the frst one will succeed and subsequent requests will be ignored.
+> ServiceComposer supports only one action result per request. If two or more composition handlers try to set action results, only the first one will succeed and subsequent requests will be ignored.

--- a/docs/composition-over-controllers.md
+++ b/docs/composition-over-controllers.md
@@ -1,6 +1,6 @@
 # Composition over controllers
 
-ServiceComposer can be used to enhance a MVC web application by adding compostion support to Controllers. ServiceComposer can be configured to use a technique called "Composition over controllers":
+ServiceComposer can be used to enhance a MVC web application by adding composition support to Controllers. ServiceComposer can be configured to use a technique called "Composition over controllers":
 
 <!-- snippet: enable-composition-over-controllers -->
 <a id='snippet-enable-composition-over-controllers'></a>

--- a/docs/custom-http-status-codes.md
+++ b/docs/custom-http-status-codes.md
@@ -20,4 +20,5 @@ public class SampleHandlerWithCustomStatusCode : ICompositionRequestsHandler
 <sup><a href='/src/Snippets/SampleHandler/SampleHandler.cs#L22-L34' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample-handler-with-custom-status-code' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-NOTE: Requests handlers are executed in parallel in a non-deterministic way, setting the response code in more than one handler can have unpredictable effects.
+> [!NOTE]
+> Requests handlers are executed in parallel in a non-deterministic way, setting the response code in more than one handler can have unpredictable effects.

--- a/docs/custom-json-response-serialization-settings.md
+++ b/docs/custom-json-response-serialization-settings.md
@@ -2,7 +2,7 @@
 
 _Available starting with v1.8.0_
 
-By default each response is serialized using [Json.Net](https://www.newtonsoft.com/json/help/html/Introduction.htm) and serialization settings (`JsonSerializerSettings`) are determined by the [requested response casing](response-serialization-casing.source.md). If the requested casing is camel casing, the default, the folowing serialization settings are applied to the response:
+By default, each response is serialized using [Json.Net](https://www.newtonsoft.com/json/help/html/Introduction.htm) and serialization settings (`JsonSerializerSettings`) are determined by the [requested response casing](response-serialization-casing.source.md). If the requested casing is camel casing, the default, the folowing serialization settings are applied to the response:
 
 <!-- snippet: camel-serialization-settings -->
 <a id='snippet-camel-serialization-settings'></a>

--- a/docs/custom-json-response-serialization-settings.md
+++ b/docs/custom-json-response-serialization-settings.md
@@ -47,5 +47,5 @@ public void ConfigureServices(IServiceCollection services)
 
 Each time ServiceComposer needs to serialize a response it'll invoke the supplied function.
 
-NOTE:
-When customizing the serialization settings, it's responsibility of the function to configure the correct resolver for the requested casing
+> [!NOTE]
+> When customizing the serialization settings, it's responsibility of the function to configure the correct resolver for the requested casing

--- a/docs/endpoint-filters.md
+++ b/docs/endpoint-filters.md
@@ -2,9 +2,11 @@
 
 _Available starting with v2.3.0_
 
+Endpoint filters allow intercepting all incoming HTTP requests prior to invoking the composition pipeline.
+
 ## Defining endpoint filters
 
-Implement `IEndpointFilter`
+Defining an endpoint filter requires defining a class that implements the `IEndpointFilter` interface, like in the following snippet:
 
 <!-- snippet: sample-endpoint-filter -->
 <a id='snippet-sample-endpoint-filter'></a>
@@ -27,6 +29,8 @@ class SampleEndpointFilter : IEndpointFilter
 <!-- endSnippet -->
 
 ## Registering endpoint filters
+
+For an endpoint filter to be included in te invocation pipeline, it must be registered at application configuration time:  
 
 <!-- snippet: sample-endpoint-filter-registration -->
 <a id='snippet-sample-endpoint-filter-registration'></a>

--- a/docs/endpoint-filters.md
+++ b/docs/endpoint-filters.md
@@ -1,0 +1,44 @@
+# Endpoint filters
+
+_Available starting with v2.3.0_
+
+## Defining endpoint filters
+
+Implement `IEndpointFilter`
+
+<!-- snippet: sample-endpoint-filter -->
+<a id='snippet-sample-endpoint-filter'></a>
+```cs
+class SampleEndpointFilter : IEndpointFilter
+{
+    public async ValueTask<object> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        // Do something meaningful prior to invoking the rest of the pipeline
+        
+        var response = await next(context);
+
+        // Do something meaningful with the response
+
+        return response;
+    }
+}
+```
+<sup><a href='/src/Snippets/EndpointFilters/SampleEndpointFilter.cs#L6-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample-endpoint-filter' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## Registering endpoint filters
+
+<!-- snippet: sample-endpoint-filter-registration -->
+<a id='snippet-sample-endpoint-filter-registration'></a>
+```cs
+public void Configure(IApplicationBuilder app)
+{
+    app.UseEndpoints(builder =>
+    {
+        builder.MapCompositionHandlers()
+            .AddEndpointFilter(new SampleEndpointFilter());
+    });
+}
+```
+<sup><a href='/src/Snippets/EndpointFilters/Startup.cs#L9-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample-endpoint-filter-registration' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/docs/options-customizations.md
+++ b/docs/options-customizations.md
@@ -2,6 +2,7 @@
 
 Assemblies containing types participating in the composition process can customize the current application `ViewModelCompositionOptions` by defining a type that implements the `IViewModelCompositionOptionsCustomization` interface. At runtime, when the application starts, types implementing the `IViewModelCompositionOptionsCustomization` will be instantiated and the `Customize` method will be invoked.
 
-> Note: Types implementing `IViewModelCompositionOptionsCustomization` are not managed by IoC container. Dependency injection is not available.
+> [!NOTE]
+> Types implementing `IViewModelCompositionOptionsCustomization` are not managed by IoC container. Dependency injection is not available.
 
 `ViewModelCompositionOptions` offers the ability to access the application `IConfiguration` instance. By default, the `ViewModelCompositionOptions.Configuration` property is null. If accessed it throws an `ArgumentException`. To enable configuration support, pass the `IConfiguration` instance when configuring ServiceComposer via the  `AddViewModelComposition` extension method.

--- a/docs/options-customizations.md
+++ b/docs/options-customizations.md
@@ -4,4 +4,4 @@ Assemblies containing types participating in the composition process can customi
 
 > Note: Types implementing `IViewModelCompositionOptionsCustomization` are not managed by IoC container. Dependency injection is not available.
 
-`ViewModelCompositionOptions` offers the ability to access the application `IConfiguration` insance. By default the `ViewModelCompositionOptions.Configuration` property is null. If accessed it throws an `ArgumentException`. To enable configuration support, pass the `IConfiguration` instance when configuring ServiceComposer via the  `AddViewModelComposition` extension method.
+`ViewModelCompositionOptions` offers the ability to access the application `IConfiguration` instance. By default, the `ViewModelCompositionOptions.Configuration` property is null. If accessed it throws an `ArgumentException`. To enable configuration support, pass the `IConfiguration` instance when configuring ServiceComposer via the  `AddViewModelComposition` extension method.

--- a/docs/output-formatters-serialization.md
+++ b/docs/output-formatters-serialization.md
@@ -2,7 +2,7 @@
 
 _Available starting with v1.9.0_
 
-Enabling output formatters support is a metter of:
+Enabling output formatters support is a matter of:
 
 <!-- snippet: use-output-formatters -->
 <a id='snippet-use-output-formatters'></a>

--- a/docs/response-serialization-casing.md
+++ b/docs/response-serialization-casing.md
@@ -1,6 +1,6 @@
 # Response serialization casing
 
-ServiceComposer serializes responses using a JSON serializer. By default responses are serialized using camel casing, a C# `SampleProperty` property is serialized as `sampleProperty`. Consumers can influence the response casing of a specific request by adding to the request an `Accept-Casing` custom HTTP header. Accepted values are `casing/camel` (default) and `casing/pascal`.
+ServiceComposer serializes responses using a JSON serializer. By default, responses are serialized using camel casing, a C# `SampleProperty` property is serialized as `sampleProperty`. Consumers can influence the response casing of a specific request by adding to the request an `Accept-Casing` custom HTTP header. Accepted values are `casing/camel` (default) and `casing/pascal`.
 
 ## Default response serialization casing
 

--- a/docs/upgrade-guides/1.x.x-2.0.0.md
+++ b/docs/upgrade-guides/1.x.x-2.0.0.md
@@ -62,7 +62,8 @@ public class SampleHandler : ICompositionRequestsHandler
 <sup><a href='/src/Snippets/UpgradeGuides/1.x-to-2.0/UpgradeGuide.cs#L38-L47' title='Snippet source file'>snippet source</a> | <a href='#snippet-composition-handler-api' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-NOTE: The `IInterceptRoutes.Matches` method has been replaced by routing attributes, `HttpGet`, `HttpPost`, etc.
+> [!NOTE]
+> The `IInterceptRoutes.Matches` method has been replaced by routing attributes, `HttpGet`, `HttpPost`, etc.
 
 ### ISubscribeToCompositionEvents -> ICompositionEventsSubscriber
 
@@ -88,7 +89,8 @@ public class SamplePublisher : ICompositionEventsSubscriber
 <sup><a href='/src/Snippets/UpgradeGuides/1.x-to-2.0/UpgradeGuide.cs#L51-L65' title='Snippet source file'>snippet source</a> | <a href='#snippet-composition-event-subscriber-api' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-NOTE: The `IInterceptRoutes.Matches`  method has been replaced by routing attributes, `HttpGet`, `HttpPost`, etc.
+> [!NOTE]
+> The `IInterceptRoutes.Matches`  method has been replaced by routing attributes, `HttpGet`, `HttpPost`, etc.
 
 ### IHandleRequestsErrors -> ICompositionErrorsHandler
 

--- a/docs/view-model-factory.md
+++ b/docs/view-model-factory.md
@@ -2,7 +2,7 @@
 
 _Available starting with v1.8.0_
 
-By default ServiceComposer uses C# `dynamic` object instances to serve view models to requests handler, when the `SalesProductInfo` handler, used in the getting started sample, requires the view model, the call to `GetComposedResponseModel()` returns a `dynamic` instance.
+By default, ServiceComposer uses C# `dynamic` object instances to serve view models to requests handler, when the `SalesProductInfo` handler, used in the getting started sample, requires the view model, the call to `GetComposedResponseModel()` returns a `dynamic` instance.
 
 The first step to use strongly typed view models is to define the view model class:
 

--- a/src/ServiceComposer.AspNetCore.Tests/When_registering_view_model_factory.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_registering_view_model_factory.cs
@@ -77,7 +77,7 @@ namespace ServiceComposer.AspNetCore.Tests
             Assert.Throws<NotSupportedException>(() =>
             {
                 // Arrange
-                var client = new SelfContainedWebApplicationFactoryWithWebHost<When_registering_view_model_factory>
+                _ = new SelfContainedWebApplicationFactoryWithWebHost<When_registering_view_model_factory>
                 (
                     configureServices: services =>
                     {

--- a/src/ServiceComposer.AspNetCore.Tests/When_setting_action_result.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_setting_action_result.cs
@@ -122,7 +122,7 @@ namespace ServiceComposer.AspNetCore.Tests
                 ).CreateClient();
 
                 // Act
-                var response = await client.GetAsync("/sample/1");
+                _ = await client.GetAsync("/sample/1");
             }
             await Assert.ThrowsAsync<NotSupportedException>(Function);
         }

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_assembly_scanner.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_assembly_scanner.cs
@@ -133,7 +133,7 @@ namespace ServiceComposer.AspNetCore.Tests
         {
             Assert.Throws<ArgumentException>(() =>
             {
-                var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_assembly_scanner>
+                _ = new SelfContainedWebApplicationFactoryWithWebHost<When_using_assembly_scanner>
                 (
                     configureServices: services =>
                     {

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_composition_and_Mvc.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_composition_and_Mvc.cs
@@ -140,8 +140,8 @@ namespace ServiceComposer.AspNetCore.Tests
             Assert.Equal("sample", responseObj?.SelectToken("AString")?.Value<string>());
             Assert.Equal(1, responseObj?.SelectToken("ANumber")?.Value<int>());
 
-            var apiResponsObj = await apiResponse.Content.ReadAsStringAsync();
-            Assert.Equal(32, int.Parse(apiResponsObj));
+            var apiResponseObj = await apiResponse.Content.ReadAsStringAsync();
+            Assert.Equal(32, int.Parse(apiResponseObj));
         }
     }
 }

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_composition_over_controllers_get_with_2_handlers.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_composition_over_controllers_get_with_2_handlers.cs
@@ -181,7 +181,7 @@ namespace ServiceComposer.AspNetCore.Tests
             try
             {
                 // Act
-                var response = await client.GetAsync("/api/CompositionOverController/1");
+                _ = await client.GetAsync("/api/CompositionOverController/1");
             }
             catch (Exception e)
             {

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -1,0 +1,82 @@
+#if NET8_0
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Tests
+{
+    public class When_using_endpoint_filters
+    {
+        class ResponseHandler : ICompositionRequestsHandler
+        {
+            [HttpGet("/empty-response/{id}")]
+            public Task Handle(HttpRequest request)
+            {
+                var vm = request.GetComposedResponseModel();
+                var ctx = request.GetCompositionContext();
+                vm.RequestId = ctx.RequestId;
+
+                return Task.CompletedTask;
+            }
+        }
+        
+        public class SampleEndpointFilter : IEndpointFilter
+        {
+            public bool Invoked { get; set; }
+            
+            public ValueTask<object> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+            {
+                Invoked = true;
+                return next(context);
+            }
+        }
+
+        [Fact]
+        public async Task Should_invoke_the_filter()
+        {
+            var expectedComposedRequestId = Guid.NewGuid().ToString();
+            var filter = new SampleEndpointFilter();
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_endpoint_filters>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.RegisterCompositionHandler<ResponseHandler>();
+                    });
+                    services.AddRouting();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder =>
+                    {
+                        builder.MapCompositionHandlers().AddEndpointFilter(filter);
+                    });
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("composed-request-id", expectedComposedRequestId);
+
+            // Act
+            var response = await client.GetAsync("/empty-response/1");
+
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.True(filter.Invoked);
+
+            var contentString = await response.Content.ReadAsStringAsync();
+            dynamic body = JObject.Parse(contentString);
+            Assert.Equal(expectedComposedRequestId, (string)body.RequestId);
+        }
+    }
+}
+#endif

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -1,4 +1,3 @@
-#if NET8_0
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -105,4 +104,3 @@ namespace ServiceComposer.AspNetCore.Tests
         }
     }
 }
-#endif

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -193,52 +193,5 @@ namespace ServiceComposer.AspNetCore
 
             return routeEndpoint;
         }
-        
-#if NET8_0
-        // static RequestDelegate Create(RequestDelegate requestDelegate, RequestDelegateFactoryOptions options)
-        // {
-        //     var serviceProvider = options.ServiceProvider ?? options.EndpointBuilder.ApplicationServices;
-        //     var jsonOptions = serviceProvider?.GetService<IOptions<JsonOptions>>()?.Value ?? new JsonOptions();
-        //     var jsonSerializerOptions = jsonOptions.SerializerOptions;
-        //
-        //     var factoryContext = new EndpointFilterFactoryContext
-        //     {
-        //         MethodInfo = requestDelegate.Method,
-        //         ApplicationServices = options.EndpointBuilder.ApplicationServices
-        //     };
-        //     var jsonTypeInfo = (JsonTypeInfo<object>)jsonSerializerOptions.GetReadOnlyTypeInfo(typeof(object));
-        //
-        //     EndpointFilterDelegate filteredInvocation = async (EndpointFilterInvocationContext context) =>
-        //     {
-        //         if (context.HttpContext.Response.StatusCode < 400)
-        //         {
-        //             await requestDelegate(context.HttpContext);
-        //         }
-        //         return EmptyHttpResult.Instance;
-        //     };
-        //
-        //     var initialFilteredInvocation = filteredInvocation;
-        //     for (var i = options.EndpointBuilder.FilterFactories.Count - 1; i >= 0; i--)
-        //     {
-        //         var currentFilterFactory = options.EndpointBuilder.FilterFactories[i];
-        //         filteredInvocation = currentFilterFactory(factoryContext, filteredInvocation);
-        //     }
-        //
-        //     // The filter factories have run without modifying per-request behavior, we can skip running the pipeline.
-        //     if (ReferenceEquals(initialFilteredInvocation, filteredInvocation))
-        //     {
-        //         return requestDelegate;
-        //     }
-        //
-        //     return async (HttpContext httpContext) =>
-        //     {
-        //         var obj = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext, new object[] { httpContext }));
-        //         if (obj is not null)
-        //         {
-        //             await ExecuteHandlerHelper.ExecuteReturnAsync(obj, httpContext, jsonTypeInfo);
-        //         }
-        //     };
-        // }
-#endif
     }
 }

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Dynamic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;

--- a/src/Snippets/ActionResult/UseSetActionResultHandler.cs
+++ b/src/Snippets/ActionResult/UseSetActionResultHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.ActionResult
+namespace Snippets.ActionResult
 {
     // begin-snippet: action-results
     public class UseSetActionResultHandler : ICompositionRequestsHandler

--- a/src/Snippets/BasicUsage/MarketingProductInfo.cs
+++ b/src/Snippets/BasicUsage/MarketingProductInfo.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.BasicUsage
+namespace Snippets.BasicUsage
 {
     // begin-snippet: basic-usage-marketing-handler
     public class MarketingProductInfo: ICompositionRequestsHandler

--- a/src/Snippets/BasicUsage/SalesProductInfo.cs
+++ b/src/Snippets/BasicUsage/SalesProductInfo.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.BasicUsage
+namespace Snippets.BasicUsage
 {
     // begin-snippet: basic-usage-sales-handler
     public class SalesProductInfo : ICompositionRequestsHandler

--- a/src/Snippets/BasicUsage/Startup.cs
+++ b/src/Snippets/BasicUsage/Startup.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.BasicUsage
+namespace Snippets.BasicUsage
 {
     // begin-snippet: sample-startup
     public class Startup

--- a/src/Snippets/CompositionOverController.cs
+++ b/src/Snippets/CompositionOverController.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x
+namespace Snippets
 {
     public class CompositionOverControllers
     {

--- a/src/Snippets/DefaultCasing/Startup.cs
+++ b/src/Snippets/DefaultCasing/Startup.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.DefaultCasing
+namespace Snippets.DefaultCasing
 {
     public class Startup
     {

--- a/src/Snippets/EndpointFilters/SampleEndpointFilter.cs
+++ b/src/Snippets/EndpointFilters/SampleEndpointFilter.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Snippets.EndpointFilters;
+
+// begin-snippet: sample-endpoint-filter
+class SampleEndpointFilter : IEndpointFilter
+{
+    public async ValueTask<object> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        // Do something meaningful prior to invoking the rest of the pipeline
+        
+        var response = await next(context);
+
+        // Do something meaningful with the response
+
+        return response;
+    }
+}
+// end-snippet

--- a/src/Snippets/EndpointFilters/Startup.cs
+++ b/src/Snippets/EndpointFilters/Startup.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using ServiceComposer.AspNetCore;
+
+namespace Snippets.EndpointFilters
+{
+    public class Startup
+    {
+        // begin-snippet: sample-endpoint-filter-registration
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseEndpoints(builder =>
+            {
+                builder.MapCompositionHandlers()
+                    .AddEndpointFilter(new SampleEndpointFilter());
+            });
+        }
+        // end-snippet
+    }
+}

--- a/src/Snippets/ModelBinding/ConfigureAppForModelBinding.cs
+++ b/src/Snippets/ModelBinding/ConfigureAppForModelBinding.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.ModelBinding
+namespace Snippets.ModelBinding
 {
     public class ConfigureAppForModelBinding
     {

--- a/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs
+++ b/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.ModelBinding
+namespace Snippets.ModelBinding
 {
     // begin-snippet: model-binding-model
     class BodyModel

--- a/src/Snippets/ModelBinding/RawBodyUsageHandler.cs
+++ b/src/Snippets/ModelBinding/RawBodyUsageHandler.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Routing;
 using Newtonsoft.Json.Linq;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.ModelBinding
+namespace Snippets.ModelBinding
 {
     class RawBodyUsageHandler : ICompositionRequestsHandler
     {

--- a/src/Snippets/SampleHandler/SampleHandler.cs
+++ b/src/Snippets/SampleHandler/SampleHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.SampleHandler
+namespace Snippets.SampleHandler
 {
     // begin-snippet: sample-handler-with-authorization
     public class SampleHandlerWithAuthorization : ICompositionRequestsHandler

--- a/src/Snippets/Serialization/ResponseSettingsBasedOnCasing.cs
+++ b/src/Snippets/Serialization/ResponseSettingsBasedOnCasing.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace Snippets.NetCore3x.Serialization
+namespace Snippets.Serialization
 {
     public class ResponseSettingsBasedOnCasing
     {

--- a/src/Snippets/Serialization/Startup.cs
+++ b/src/Snippets/Serialization/Startup.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.Serialization
+namespace Snippets.Serialization
 {
     public class Startup
     {

--- a/src/Snippets/Serialization/UseOutputFormatters.cs
+++ b/src/Snippets/Serialization/UseOutputFormatters.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.Serialization
+namespace Snippets.Serialization
 {
     public class UseOutputFormatters
     {

--- a/src/Snippets/UpgradeGuides/1.x-to-2.0/UpgradeGuide.cs
+++ b/src/Snippets/UpgradeGuides/1.x-to-2.0/UpgradeGuide.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.UpgradeGuides._1.x_to_2._0;
+namespace Snippets.UpgradeGuides._1.x_to_2._0;
 
 public class UpgradeGuide
 {

--- a/src/Snippets/ViewModelFactory/MarketingProductInfo.cs
+++ b/src/Snippets/ViewModelFactory/MarketingProductInfo.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
 
-namespace Snipptes.ViewModelFactory
+namespace Snippets.ViewModelFactory
 {
     // begin-snippet: view-model-factory-marketing-handler
     public class MarketingProductInfo: ICompositionRequestsHandler

--- a/src/Snippets/ViewModelFactory/ProductViewModel.cs
+++ b/src/Snippets/ViewModelFactory/ProductViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Snipptes.ViewModelFactory
+﻿namespace Snippets.ViewModelFactory
 {
     // begin-snippet: view-model-factory-product-view-model
     public class ProductViewModel

--- a/src/Snippets/ViewModelFactory/ProductViewModelFactory.cs
+++ b/src/Snippets/ViewModelFactory/ProductViewModelFactory.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using ServiceComposer.AspNetCore;
 
-namespace Snipptes.ViewModelFactory
+namespace Snippets.ViewModelFactory
 {
     // begin-snippet: view-model-factory-product-view-model-factory
     class ProductViewModelFactory : IEndpointScopedViewModelFactory

--- a/src/Snippets/ViewModelFactory/SalesProductInfo.cs
+++ b/src/Snippets/ViewModelFactory/SalesProductInfo.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ServiceComposer.AspNetCore;
 
-namespace Snipptes.ViewModelFactory
+namespace Snippets.ViewModelFactory
 {
     // begin-snippet: view-model-factory-sales-handler
     public class SalesProductInfo : ICompositionRequestsHandler

--- a/src/Snippets/WriteSupport/EnableWriteSupport.cs
+++ b/src/Snippets/WriteSupport/EnableWriteSupport.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using ServiceComposer.AspNetCore;
 
-namespace Snippets.NetCore3x.WriteSupport;
+namespace Snippets.WriteSupport;
 
 public class EnableWriteSupport
 {


### PR DESCRIPTION
This PR adds support for endpoint filters, which are classes implementing the regular `IEndpointFilter` APS.Net interface. Once a filter is defined and registered, it will be invoked for every HTTP request.

This PR introduces a minimal handling pipeline (in `BuildAndCacheEndpointFilterDelegatePipeline`), allowing filters to be chained. The pipeline is largely inspired by the one in ASP.Net to handle filters there.

## PoA

- [x] PR description
- [x] Apply labels as appropriate
- [x] tests
- [x] documentation
