### PR TITLE
Add support for composition request filters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,3 +40,7 @@ It's possible to access and [customize ViewModel Composition options](options-cu
 ## Endpoint filters
 
 Endpoint filters allow intercepting all incoming HTTP requests before they reach the composition stage. For more information refer to the [endpoint filters documentation](endpoint-filters.md).
+
+## Composition requests filters
+
+Composition requests filters allow intercepting compostion requests before they are dispatched to composition handlers. For more information refer to the [Composition requests filters documentation](composition-filters.md).

--- a/docs/composition-filters.md
+++ b/docs/composition-filters.md
@@ -1,0 +1,71 @@
+# Composition requests filters
+
+_Available starting with v2.3.0_
+
+Composition requests filters allow intercepting composition requests to specific composition handlers. Contrary to [endpoint filters](endpoint-filters.md) that are generic HTTP filters, composition filters sit right in front of the composition handlers they are configured to intercept.
+
+## Defining composition requests filters
+
+Composition requests filter can be defined as attributes or as classes.
+
+### Defining composition requests filters as attributes
+
+Create an attribute that inherites from `CompositionRequestFilterAttribute` like in the following snippet:
+
+<!-- snippet: composition-filter-attribute -->
+<a id='snippet-composition-filter-attribute'></a>
+```cs
+public class SampleCompositionFilterAttribute : CompositionRequestFilterAttribute
+{
+    public override ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next)
+    {
+        return next(context);
+    }
+}
+```
+<sup><a href='/src/Snippets/CompositionFilters/SampleHandler.cs#L9-L17' title='Snippet source file'>snippet source</a> | <a href='#snippet-composition-filter-attribute' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+> [!NOTE]
+> The `InvokeAsync` implementation is responsible to invoke the next filter in the pipeline.
+
+Apply the attribute to the composition handlers to intercept:
+
+<!-- snippet: handler-with-composition-filter -->
+<a id='snippet-handler-with-composition-filter'></a>
+```cs
+public class SampleHandler : ICompositionRequestsHandler
+{
+    [SampleCompositionFilter]
+    [HttpGet("/sample/{id}")]
+    public Task Handle(HttpRequest request)
+    {
+        return Task.CompletedTask;
+    }
+}
+```
+<sup><a href='/src/Snippets/CompositionFilters/SampleHandler.cs#L29-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-handler-with-composition-filter' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+### Defining composition requests filters as classes
+
+Create a class te implements the `ICompositionRequestFilter<T>` interface, where the generic `T` parameter is the composition handler type to intercept:
+
+<!-- snippet: composition-filter-class -->
+<a id='snippet-composition-filter-class'></a>
+```cs
+public class SampleCompositionFilter : ICompositionRequestFilter<SampleHandler>
+{
+    public ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next)
+    {
+        return next(context);
+    }
+}
+```
+<sup><a href='/src/Snippets/CompositionFilters/SampleHandler.cs#L19-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-composition-filter-class' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The above snippet defines a filter intercepting requests to the `SampleHandler` composition handler.
+
+> [!NOTE]
+> Filters defined as classes implementing the `ICompositionRequestFilter<T>` interface will be automatically registered in DI as transiten, and can use DI to resolve dependencies.

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -20,6 +20,17 @@ namespace ServiceComposer.AspNetCore
     }
     public delegate System.Threading.Tasks.Task CompositionEventHandler<in TEvent>(TEvent @event, Microsoft.AspNetCore.Http.HttpRequest httpRequest);
     public static class CompositionHandler { }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method)]
+    public abstract class CompositionRequestFilterAttribute : System.Attribute, ServiceComposer.AspNetCore.ICompositionRequestFilter
+    {
+        protected CompositionRequestFilterAttribute() { }
+        public abstract System.Threading.Tasks.ValueTask<object> InvokeAsync(ServiceComposer.AspNetCore.CompositionRequestFilterContext context, ServiceComposer.AspNetCore.CompositionRequestFilterDelegate next);
+    }
+    public sealed class CompositionRequestFilterContext
+    {
+        public Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
+    }
+    public delegate System.Threading.Tasks.ValueTask<object> CompositionRequestFilterDelegate(ServiceComposer.AspNetCore.CompositionRequestFilterContext context);
     public static class EndpointsExtensions
     {
         public static Microsoft.AspNetCore.Builder.IEndpointConventionBuilder MapCompositionHandlers(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints) { }
@@ -61,6 +72,11 @@ namespace ServiceComposer.AspNetCore
     {
         void Subscribe(ServiceComposer.AspNetCore.ICompositionEventsPublisher publisher);
     }
+    public interface ICompositionRequestFilter
+    {
+        System.Threading.Tasks.ValueTask<object> InvokeAsync(ServiceComposer.AspNetCore.CompositionRequestFilterContext context, ServiceComposer.AspNetCore.CompositionRequestFilterDelegate next);
+    }
+    public interface ICompositionRequestFilter<T> : ServiceComposer.AspNetCore.ICompositionRequestFilter { }
     public interface ICompositionRequestsHandler
     {
         System.Threading.Tasks.Task Handle(Microsoft.AspNetCore.Http.HttpRequest request);

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_composition_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_composition_filters.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Tests
+{
+    public class When_using_composition_filters
+    {
+        [SampleCompositionRequestFilter, AnotherSampleCompositionRequestFilter]
+        class ResponseHandler : ICompositionRequestsHandler
+        {
+            [HttpGet("/empty-response/{id}"), SampleCompositionRequestFilter]
+            public Task Handle(HttpRequest request)
+            {
+                var vm = request.GetComposedResponseModel();
+                var ctx = request.GetCompositionContext();
+                vm.RequestId = ctx.RequestId;
+
+                return Task.CompletedTask;
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+        abstract class CompositionRequestFilterAttribute : Attribute
+        {
+            
+        }
+
+        class CompositionRequestContext
+        {
+            public HttpRequest Request { get; }
+        }
+
+        interface ICompositionRequestFilter<T>
+        {
+            ValueTask<object> InvokeAsync(CompositionRequestContext context, CompositionDelegate next);
+        }
+        
+        class SampleCompositionRequestFilterAttribute : CompositionRequestFilterAttribute
+        {
+            public bool Invoked { get; set; }
+            public object CapturedResponse { get; set; }
+            
+            public async ValueTask<object> InvokeAsync(CompositionRequestContext context, CompositionDelegate next)
+            {
+                Invoked = true;
+                CapturedResponse = await next(context);
+
+                return CapturedResponse;
+            }
+        }
+        
+        class AnotherSampleCompositionRequestFilterAttribute : CompositionRequestFilterAttribute
+        {
+            public bool Invoked { get; set; }
+            public object CapturedResponse { get; set; }
+            
+            public async ValueTask<object> InvokeAsync(CompositionRequestContext context, CompositionDelegate next)
+            {
+                Invoked = true;
+                CapturedResponse = await next(context);
+
+                return CapturedResponse;
+            }
+        }
+        
+        class SampleCompositionRequestFilter : ICompositionRequestFilter<ResponseHandler>
+        {
+            public bool Invoked { get; set; }
+            public object CapturedResponse { get; set; }
+            
+            public async ValueTask<object> InvokeAsync(ICompositionContext context, CompositionDelegate next)
+            {
+                Invoked = true;
+                CapturedResponse = await next(context);
+
+                return CapturedResponse;
+            }
+        }
+
+        [Fact]
+        public async Task Should_invoke_the_filter()
+        {
+            var expectedComposedRequestId = Guid.NewGuid().ToString();
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_endpoint_filters>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.ResponseSerialization.DefaultResponseCasing = ResponseCasing.PascalCase;
+                        options.RegisterCompositionHandler<ResponseHandler>();
+                    });
+                    services.AddRouting();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder =>
+                    {
+                        builder.MapCompositionHandlers();
+                    });
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("composed-request-id", expectedComposedRequestId);
+
+            // Act
+            var response = await client.GetAsync("/empty-response/1");
+
+            Assert.True(response.IsSuccessStatusCode);
+
+            var contentString = await response.Content.ReadAsStringAsync();
+            dynamic body = JObject.Parse(contentString);
+            Assert.Equal(expectedComposedRequestId, (string)body.RequestId);
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_composition_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_composition_filters.cs
@@ -12,7 +12,7 @@ namespace ServiceComposer.AspNetCore.Tests
 {
     public class When_using_composition_filters
     {
-        //[SampleCompositionRequestFilter, AnotherSampleCompositionRequestFilter]
+        //[SampleCompositionRequestFilterOnClass, AnotherSampleCompositionRequestFilterOnClass]
         class ResponseHandler : ICompositionRequestsHandler
         {
             [HttpGet("/empty-response/{id}"), SampleCompositionRequestFilter]
@@ -39,31 +39,31 @@ namespace ServiceComposer.AspNetCore.Tests
             }
         }
         
-        class SampleCompositionRequestFilterOnClassAttribute : CompositionRequestFilterAttribute
-        {
-            public override async ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next)
-            {
-                await next(context);
-
-                var vm = context.HttpContext.Request.GetComposedResponseModel();
-                vm.InvokedSampleCompositionRequestFilterOnClassAttribute = true;
-
-                return vm;
-            }
-        }
-        
-        class AnotherSampleCompositionRequestFilterOnClassAttribute : CompositionRequestFilterAttribute
-        {
-            public override async ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next)
-            {
-                await next(context);
-
-                var vm = context.HttpContext.Request.GetComposedResponseModel();
-                vm.InvokedAnotherSampleCompositionRequestFilterOnClassAttribute = true;
-                
-                return vm;
-            }
-        }
+        // class SampleCompositionRequestFilterOnClassAttribute : CompositionRequestFilterAttribute
+        // {
+        //     public override async ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next)
+        //     {
+        //         await next(context);
+        //
+        //         var vm = context.HttpContext.Request.GetComposedResponseModel();
+        //         vm.InvokedSampleCompositionRequestFilterOnClassAttribute = true;
+        //
+        //         return vm;
+        //     }
+        // }
+        //
+        // class AnotherSampleCompositionRequestFilterOnClassAttribute : CompositionRequestFilterAttribute
+        // {
+        //     public override async ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next)
+        //     {
+        //         await next(context);
+        //
+        //         var vm = context.HttpContext.Request.GetComposedResponseModel();
+        //         vm.InvokedAnotherSampleCompositionRequestFilterOnClassAttribute = true;
+        //         
+        //         return vm;
+        //     }
+        // }
         
         class InvokedSampleCompositionRequestFilterInterface : ICompositionRequestFilter<ResponseHandler>
         {
@@ -119,8 +119,8 @@ namespace ServiceComposer.AspNetCore.Tests
             Assert.Equal(expectedComposedRequestId, (string)body.RequestId);
             Assert.True((bool)body.InvokedSampleCompositionRequestFilterAttribute);
             Assert.True((bool)body.InvokedSampleCompositionRequestFilterInterface);
-            //Assert.True(body.InvokedSampleCompositionRequestFilterOnClassAttribute);
-            //Assert.True(body.InvokedAnotherSampleCompositionRequestFilterOnClassAttribute);
+            // Assert.True((bool)body.InvokedSampleCompositionRequestFilterOnClassAttribute);
+            // Assert.True((bool)body.InvokedAnotherSampleCompositionRequestFilterOnClassAttribute);
         }
     }
 }

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_composition_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_composition_filters.cs
@@ -93,6 +93,7 @@ namespace ServiceComposer.AspNetCore.Tests
                         options.AssemblyScanner.Disable();
                         options.ResponseSerialization.DefaultResponseCasing = ResponseCasing.PascalCase;
                         options.RegisterCompositionHandler<ResponseHandler>();
+                        options.RegisterCompositionRequestsFilter(typeof(InvokedSampleCompositionRequestFilterInterface));
                     });
                     services.AddRouting();
                 },
@@ -117,7 +118,7 @@ namespace ServiceComposer.AspNetCore.Tests
             dynamic body = JObject.Parse(contentString);
             Assert.Equal(expectedComposedRequestId, (string)body.RequestId);
             Assert.True((bool)body.InvokedSampleCompositionRequestFilterAttribute);
-            //Assert.True(body.InvokedSampleCompositionRequestFilterInterface);
+            Assert.True((bool)body.InvokedSampleCompositionRequestFilterInterface);
             //Assert.True(body.InvokedSampleCompositionRequestFilterOnClassAttribute);
             //Assert.True(body.InvokedAnotherSampleCompositionRequestFilterOnClassAttribute);
         }

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.CompositionFilters.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.CompositionFilters.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ServiceComposer.AspNetCore;
+
+partial class CompositionEndpointBuilder
+{
+   CompositionRequestFilterDelegate BuildCompositionRequestFilterDelegatePipeline(RequestDelegate composer, IServiceProvider serviceProvider)
+    {
+        List<Func<CompositionRequestFilterFactoryContext, CompositionRequestFilterDelegate, CompositionRequestFilterDelegate>> compositionRequestFilterFactories = [];
+        var compositionRequestFilters = Metadata
+            .Where(obj => obj is ICompositionRequestFilter)
+            .Cast<ICompositionRequestFilter>()
+            .ToList();
+        foreach (var componentType in componentsTypes)
+        {
+            var typeBasedCompositionFilterType = typeof(ICompositionRequestFilter<>).MakeGenericType(componentType);
+            if (serviceProvider.GetService(typeBasedCompositionFilterType) is ICompositionRequestFilter typeBasedCompositionFilter)
+            {
+                compositionRequestFilters.Add(typeBasedCompositionFilter);
+            }
+        }
+        
+        compositionRequestFilters.ForEach(filter =>
+        {
+            compositionRequestFilterFactories.Add((factoryContext, next) => (context) => filter.InvokeAsync(context, next));
+        });
+
+        CompositionRequestFilterDelegate filteredInvocation = async context =>
+        {
+            await composer(context.HttpContext);
+            var viewModel = context.HttpContext.Request.GetComposedResponseModel();
+
+            return viewModel;
+        };
+
+        var factoryContext = new CompositionRequestFilterFactoryContext();
+        
+        var terminatorFilterDelegate = filteredInvocation;
+        for (var i = compositionRequestFilterFactories.Count - 1; i >= 0; i--)
+        {
+            var currentFilterFactory = compositionRequestFilterFactories[i];
+            filteredInvocation = currentFilterFactory(factoryContext, filteredInvocation);
+        }
+        
+        return ReferenceEquals(terminatorFilterDelegate, filteredInvocation)
+            ? terminatorFilterDelegate // The filter factories have run without modifications, skip running the pipeline.
+            : filteredInvocation;
+    }
+
+}

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.CompositionFilters.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.CompositionFilters.cs
@@ -40,16 +40,17 @@ partial class CompositionEndpointBuilder
 
         var factoryContext = new CompositionRequestFilterFactoryContext();
         
-        var terminatorFilterDelegate = filteredInvocation;
+        //var terminatorFilterDelegate = filteredInvocation;
         for (var i = compositionRequestFilterFactories.Count - 1; i >= 0; i--)
         {
             var currentFilterFactory = compositionRequestFilterFactories[i];
             filteredInvocation = currentFilterFactory(factoryContext, filteredInvocation);
         }
         
-        return ReferenceEquals(terminatorFilterDelegate, filteredInvocation)
-            ? terminatorFilterDelegate // The filter factories have run without modifications, skip running the pipeline.
-            : filteredInvocation;
+        // return ReferenceEquals(terminatorFilterDelegate, filteredInvocation)
+        //     ? terminatorFilterDelegate // The filter factories have run without modifications, skip running the pipeline.
+        //     : filteredInvocation;
+        return filteredInvocation;
     }
 
 }

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.EndpointFilters.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.EndpointFilters.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ServiceComposer.AspNetCore;
+
+partial class CompositionEndpointBuilder
+{
+    static readonly object buildAndCacheEndpointFilterDelegatePipelineSyncLock = new ();
+    EndpointFilterDelegate BuildAndCacheEndpointFilterDelegatePipeline(RequestDelegate composer, IServiceProvider serviceProvider)
+    {
+        lock (buildAndCacheEndpointFilterDelegatePipelineSyncLock)
+        {
+            var compositionFiltersPipeline = BuildCompositionRequestFilterDelegatePipeline(composer, serviceProvider);
+            
+            var factoryContext = new EndpointFilterFactoryContext
+            {
+                MethodInfo = compositionFiltersPipeline.Method,
+                ApplicationServices = serviceProvider
+            };
+
+            EndpointFilterDelegate filteredInvocation = async context =>
+            {
+                if (context.HttpContext.Response.StatusCode < 400)
+                {
+                    var viewModel = await compositionFiltersPipeline(new CompositionRequestFilterContext(context.HttpContext));
+
+                    var containsActionResult =
+                        context.HttpContext.Items.ContainsKey(HttpRequestExtensions.ComposedActionResultKey);
+                    switch (useOutputFormatters)
+                    {
+                        case false when containsActionResult:
+                            throw new NotSupportedException(
+                                $"Setting an action result requires output formatters supports. " +
+                                $"Enable output formatters by setting to true the {nameof(ResponseSerializationOptions.UseOutputFormatters)} " +
+                                $"configuration property in the {nameof(ResponseSerializationOptions)} options.");
+                        case true when containsActionResult:
+                            return context.HttpContext.Items[HttpRequestExtensions.ComposedActionResultKey] as
+                                IActionResult;
+                    }
+
+                    return viewModel;
+                }
+
+                return EmptyHttpResult.Instance;
+            };
+
+            var terminatorFilterDelegate = filteredInvocation;
+            for (var i = FilterFactories.Count - 1; i >= 0; i--)
+            {
+                var currentFilterFactory = FilterFactories[i];
+                filteredInvocation = currentFilterFactory(factoryContext, filteredInvocation);
+            }
+
+            cachedPipeline = ReferenceEquals(terminatorFilterDelegate, filteredInvocation)
+                ? terminatorFilterDelegate // The filter factories have run without modifications, skip running the pipeline.
+                : filteredInvocation;
+
+            return cachedPipeline;
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.EndpointFilters.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.EndpointFilters.cs
@@ -46,16 +46,17 @@ partial class CompositionEndpointBuilder
                 return EmptyHttpResult.Instance;
             };
 
-            var terminatorFilterDelegate = filteredInvocation;
+            //var terminatorFilterDelegate = filteredInvocation;
             for (var i = FilterFactories.Count - 1; i >= 0; i--)
             {
                 var currentFilterFactory = FilterFactories[i];
                 filteredInvocation = currentFilterFactory(factoryContext, filteredInvocation);
             }
 
-            cachedPipeline = ReferenceEquals(terminatorFilterDelegate, filteredInvocation)
-                ? terminatorFilterDelegate // The filter factories have run without modifications, skip running the pipeline.
-                : filteredInvocation;
+            // cachedPipeline = ReferenceEquals(terminatorFilterDelegate, filteredInvocation)
+            //     ? terminatorFilterDelegate // The filter factories have run without modifications, skip running the pipeline.
+            //     : filteredInvocation;
+            cachedPipeline = filteredInvocation;
 
             return cachedPipeline;
         }

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -159,7 +159,7 @@ namespace ServiceComposer.AspNetCore
                         case false when containsActionResult:
                             throw new NotSupportedException($"Setting an action result requires output formatters supports. " +
                                                             $"Enable output formatters by setting to true the {nameof(ResponseSerializationOptions.UseOutputFormatters)} " +
-                                                            $"configuration property in the {nameof(ResponseSerializationOptions)} options.");
+                                                            $"configuration property of the {nameof(ResponseSerializationOptions)} instance.");
                         case true when containsActionResult:
                             await context.ExecuteResultAsync(context.Items[HttpRequestExtensions.ComposedActionResultKey] as IActionResult);
                             break;

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
@@ -13,7 +12,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace ServiceComposer.AspNetCore
 {
-    class CompositionEndpointBuilder : EndpointBuilder
+    partial class CompositionEndpointBuilder : EndpointBuilder
     {
         readonly Dictionary<ResponseCasing, JsonSerializerSettings> casingToSettingsMappings = new();
         readonly RoutePattern routePattern;
@@ -86,59 +85,6 @@ namespace ServiceComposer.AspNetCore
             }
 
             return customSettings ?? casingToSettingsMappings[casing];
-        }
-
-        static object buildAndCacheEndpointFilterDelegatePipelineSyncLock = new ();
-        EndpointFilterDelegate BuildAndCacheEndpointFilterDelegatePipeline(RequestDelegate composer, IServiceProvider serviceProvider)
-        {
-            lock (buildAndCacheEndpointFilterDelegatePipelineSyncLock)
-            {
-                var factoryContext = new EndpointFilterFactoryContext
-                {
-                    MethodInfo = composer.Method,
-                    ApplicationServices = serviceProvider
-                };
-
-                EndpointFilterDelegate filteredInvocation = async context =>
-                {
-                    if (context.HttpContext.Response.StatusCode < 400)
-                    {
-                        await composer(context.HttpContext);
-                        var viewModel = context.HttpContext.Request.GetComposedResponseModel();
-
-                        var containsActionResult =
-                            context.HttpContext.Items.ContainsKey(HttpRequestExtensions.ComposedActionResultKey);
-                        switch (useOutputFormatters)
-                        {
-                            case false when containsActionResult:
-                                throw new NotSupportedException(
-                                    $"Setting an action result requires output formatters supports. " +
-                                    $"Enable output formatters by setting to true the {nameof(ResponseSerializationOptions.UseOutputFormatters)} " +
-                                    $"configuration property in the {nameof(ResponseSerializationOptions)} options.");
-                            case true when containsActionResult:
-                                return context.HttpContext.Items[HttpRequestExtensions.ComposedActionResultKey] as
-                                    IActionResult;
-                        }
-
-                        return viewModel;
-                    }
-
-                    return EmptyHttpResult.Instance;
-                };
-
-                var terminatorFilterDelegate = filteredInvocation;
-                for (var i = FilterFactories.Count - 1; i >= 0; i--)
-                {
-                    var currentFilterFactory = FilterFactories[i];
-                    filteredInvocation = currentFilterFactory(factoryContext, filteredInvocation);
-                }
-
-                cachedPipeline = ReferenceEquals(terminatorFilterDelegate, filteredInvocation)
-                    ? terminatorFilterDelegate // The filter factories have run without modifications, skip running the pipeline.
-                    : filteredInvocation;
-
-                return cachedPipeline;
-            }
         }
 
         public override Endpoint Build()

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointDataSource.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointDataSource.cs
@@ -11,8 +11,8 @@ namespace ServiceComposer.AspNetCore
 {
     class CompositionEndpointDataSource : EndpointDataSource, IEndpointConventionBuilder
     {
-        readonly List<Action<EndpointBuilder>> conventions = new();
-        readonly List<CompositionEndpointBuilder> _endpointBuilders = new List<CompositionEndpointBuilder>();
+        readonly List<Action<EndpointBuilder>> conventions = [];
+        readonly List<CompositionEndpointBuilder> _endpointBuilders = [];
 
         public void AddEndpointBuilder(CompositionEndpointBuilder endpointBuilder)
         {

--- a/src/ServiceComposer.AspNetCore/CompositionRequestFilterAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionRequestFilterAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+
+namespace ServiceComposer.AspNetCore;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public abstract class CompositionRequestFilterAttribute : Attribute, ICompositionRequestFilter
+{
+    public abstract ValueTask<object> InvokeAsync(CompositionRequestFilterContext context,
+        CompositionRequestFilterDelegate next);
+}

--- a/src/ServiceComposer.AspNetCore/CompositionRequestFilterContext.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionRequestFilterContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Http;
+
+namespace ServiceComposer.AspNetCore;
+
+public sealed class CompositionRequestFilterContext
+{
+    internal CompositionRequestFilterContext(HttpContext httpContext)
+    {
+        HttpContext = httpContext;
+    }
+
+    public HttpContext HttpContext { get; }
+}

--- a/src/ServiceComposer.AspNetCore/CompositionRequestFilterDelegate.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionRequestFilterDelegate.cs
@@ -1,0 +1,5 @@
+using System.Threading.Tasks;
+
+namespace ServiceComposer.AspNetCore;
+
+public delegate ValueTask<object> CompositionRequestFilterDelegate(CompositionRequestFilterContext context);

--- a/src/ServiceComposer.AspNetCore/CompositionRequestFilterFactoryContext.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionRequestFilterFactoryContext.cs
@@ -1,0 +1,6 @@
+namespace ServiceComposer.AspNetCore;
+
+class CompositionRequestFilterFactoryContext
+{
+    
+}

--- a/src/ServiceComposer.AspNetCore/EndpointsExtensions.cs
+++ b/src/ServiceComposer.AspNetCore/EndpointsExtensions.cs
@@ -239,11 +239,17 @@ namespace ServiceComposer.AspNetCore
             };
             builder.Metadata.Add(methodMetadata);
 
-            var attributes = componentsGroup.SelectMany(component => component.Method.GetCustomAttributes());
-            foreach (var attribute in attributes)
+            var methodAttributes = componentsGroup.SelectMany(component => component.Method.GetCustomAttributes(inherit: true));
+            foreach (var attribute in methodAttributes)
             {
                 builder.Metadata.Add(attribute);
             }
+
+            // var classAttributes = componentsGroup.SelectMany(component => component.ComponentType.GetCustomAttributes(inherit: true));
+            // foreach (var attribute in classAttributes)
+            // {
+            //     builder.Metadata.Add(attribute);
+            // }
 
             return builder;
         }

--- a/src/ServiceComposer.AspNetCore/ICompositionRequestFilter.cs
+++ b/src/ServiceComposer.AspNetCore/ICompositionRequestFilter.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace ServiceComposer.AspNetCore;
+
+public interface ICompositionRequestFilter
+{
+    ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next);
+}
+
+public interface ICompositionRequestFilter<T> : ICompositionRequestFilter;

--- a/src/Snippets/CompositionFilters/SampleHandler.cs
+++ b/src/Snippets/CompositionFilters/SampleHandler.cs
@@ -1,0 +1,40 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using ServiceComposer.AspNetCore;
+
+namespace Snippets.CompositionFilters
+{
+    // begin-snippet: composition-filter-attribute
+    public class SampleCompositionFilterAttribute : CompositionRequestFilterAttribute
+    {
+        public override ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next)
+        {
+            return next(context);
+        }
+    }
+    // end-snippet
+    
+    // begin-snippet: composition-filter-class
+    public class SampleCompositionFilter : ICompositionRequestFilter<SampleHandler>
+    {
+        public ValueTask<object> InvokeAsync(CompositionRequestFilterContext context, CompositionRequestFilterDelegate next)
+        {
+            return next(context);
+        }
+    }
+    // end-snippet
+    
+    // begin-snippet: handler-with-composition-filter
+    public class SampleHandler : ICompositionRequestsHandler
+    {
+        [SampleCompositionFilter]
+        [HttpGet("/sample/{id}")]
+        public Task Handle(HttpRequest request)
+        {
+            return Task.CompletedTask;
+        }
+    }
+    // end-snippet
+}


### PR DESCRIPTION
This PR adds support for composition request filters. Contrary to endpoint filters that intercept every incoming HTTP request, composition request filters sit right before each composition request handler. They can be defined using attributes inheriting from `CompositionRequestFilterAttribute` or classes implementing the `ICompositionRequestFilter<T>` interface, where the generic parameter `T` is the composition handler to intercept. 

This PR implements the following:

- automatic registration in DI of classes implementing the `ICompositionRequestFilter` interface
- The `CompositionRequestFilterAttribute` implements the `ICompositionRequestFilter` interface, but attributes are excluded from DI registration
- the construction of a pipeline of composition request filters leading to the composition handler

## PoA

- [x] PR description
- [x] Apply labels as appropriate
- [x] tests
- [x] documentation
