### PR TITLE
Expand dependencies range to support .NET 9 and add .NET 9 as a target in tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ ServiceComposer can be added to existing or new ASP.NET Core projects, or it can
 
 ## Supported .NET versions
 
-ServiceComposer targets .NET 8.
+ServiceComposer targets .NET 8. Tests are executed against .NET 8 and .NET 9.
 
 ## Note about thread safety
 

--- a/src/ServiceComposer.AspNetCore.Tests/ServiceComposer.AspNetCore.Tests.csproj
+++ b/src/ServiceComposer.AspNetCore.Tests/ServiceComposer.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,9 +17,19 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="9.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
-    <PackageReference Include="System.Reflection.Metadata" Version="8.0.1" />
+    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="2.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,7 +38,6 @@
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
-    <PackageReference Include="ServiceComposer.AspNetCore.Testing" Version="2.1.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <!-- this is needed to allow tests to correctly load the xunit.runner.utility required by Verify.Xunit --> 
     <PackageReference Include="xunit.runner.utility" Version="2.9.2" />

--- a/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
+++ b/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
@@ -52,12 +52,4 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <Target Name="AppVeyorPullRequestsTarget" AfterTargets="MinVer" Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''">
-    <PropertyGroup>
-      <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(APPVEYOR_PULL_REQUEST_NUMBER).build-id.$(APPVEYOR_BUILD_ID).$(MinVerPreRelease)</PackageVersion>
-      <PackageVersion Condition="'$(MinVerBuildMetadata)' != ''">$(PackageVersion)+$(MinVerBuildMetadata)</PackageVersion>
-      <Version>$(PackageVersion)</Version>
-    </PropertyGroup>
-  </Target>
-
 </Project>

--- a/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
+++ b/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
@@ -36,8 +36,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
     <PackageReference Include="System.ValueTuple" Version="[4.5.0, 5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="[8.0.0, 9.0.0)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="[8.0.0, 9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="[8.0.0, 10.0.0)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="[8.0.0, 10.0.0)" />
   </ItemGroup>
 
   <ItemGroup Label="Dependencies not directly used but required to address security vulnerabilities">

--- a/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
+++ b/src/ServiceComposer.AspNetCore/ServiceComposer.AspNetCore.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Dependencies not directly used but required to address security vulnerabilities">
-    <PackageReference Include="System.Text.Json" Version="[8.0.5, 9.0.0)" />
+    <PackageReference Include="System.Text.Json" Version="[8.0.5, 10.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR expands the dependencies range to support targeting .NET 9 dependencies. Consequently, tests are also targeting .NET 9 in addition to .NET 8.

## PoA

- [x] PR description
- [x] Apply labels as appropriate
- [x] tests
- [x] documentation
