### PR TITLE
Scan AppDomain assemblies, do not try loading already loaded assemblies

### DIFF
--- a/src/ServiceComposer.AspNetCore/AssemblyScanner.cs
+++ b/src/ServiceComposer.AspNetCore/AssemblyScanner.cs
@@ -48,7 +48,7 @@ namespace ServiceComposer.AspNetCore
             {
                 if (FullPathsFilter(assembly.Location))
                 {
-                    assemblies.Add(assembly.GetName().FullName, assembly);   
+                    assemblies.TryAdd(assembly.GetName().FullName, assembly);
                 }
             }
 


### PR DESCRIPTION
Under certain circumstances, primarily in Unit Tests, the Assembly Scanner might fail because it tries to load already loaded assemblies. The pull request introduces the following changes:

1. The scanner first scans AppDomain assemblies
2. The scanner now uses a dictionary (key: Assembly full name) to keep track of already loaded assemblies
3. The scanner try/catches FileLoadException exceptions when using `Assembly.LoadFrom` 