### PR TITLE
Add support for declarative model binding

### DIFF
--- a/docs/endpoint-filters.md
+++ b/docs/endpoint-filters.md
@@ -46,3 +46,9 @@ public void Configure(IApplicationBuilder app)
 ```
 <sup><a href='/src/Snippets/EndpointFilters/Startup.cs#L9-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample-endpoint-filter-registration' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+## Accessing arguments
+
+The endpoint filters API exposes through the `EndpointFilterInvocationContext` the list of arguments that the ASP.Net model binding engire determined as needed by the later invoked controller action. When using regular composition handlers, e.g. by implemeting the `ICompositionHandler` interface, ServiceComposer cannot determine which arguments are latwer needed by the user composition code. To overcome this limitation and allow the arguments list to be populated and accessible by filters, it's required to use a [declarative model binding approach](model-binding.md#declarative-model-binding).
+
+[foo](model-binding.md#named-arguments-experimental-api)

--- a/docs/endpoint-filters.md
+++ b/docs/endpoint-filters.md
@@ -49,6 +49,6 @@ public void Configure(IApplicationBuilder app)
 
 ## Accessing arguments
 
-The endpoint filters API exposes through the `EndpointFilterInvocationContext` the list of arguments that the ASP.Net model binding engire determined as needed by the later invoked controller action. When using regular composition handlers, e.g. by implemeting the `ICompositionHandler` interface, ServiceComposer cannot determine which arguments are latwer needed by the user composition code. To overcome this limitation and allow the arguments list to be populated and accessible by filters, it's required to use a [declarative model binding approach](model-binding.md#declarative-model-binding).
+The endpoint filters API exposes through the `EndpointFilterInvocationContext` the list of arguments that the ASP.Net model binding engire determined as needed by the later invoked controller action. When using regular composition handlers, e.g. by implemeting the `ICompositionRequestsHandler` interface, ServiceComposer cannot determine which arguments are latwer needed by the user composition code. To overcome this limitation and allow the arguments list to be populated and accessible by filters, it's required to use a [declarative model binding approach](model-binding.md#declarative-model-binding).
 
 [foo](model-binding.md#named-arguments-experimental-api)

--- a/docs/model-binding.md
+++ b/docs/model-binding.md
@@ -78,7 +78,7 @@ class BodyModel
     public string AString { get; set; }
 }
 ```
-<sup><a href='/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs#L8-L13' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-model' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/ModelBinding/BodyModel.cs#L3-L8' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-model' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 > The class name is irrelevant
@@ -90,11 +90,11 @@ Once we have a model for the body, a model that represent the incoming request i
 ```cs
 class RequestModel
 {
-    [FromRoute] public int id { get; set; }
+    [FromRoute(Name = "id")] public int Id { get; set; }
     [FromBody] public BodyModel Body { get; set; }
 }
 ```
-<sup><a href='/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs#L15-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-request' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/ModelBinding/RequestModel.cs#L5-L11' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-request' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 > The class name is irrelevant. The name of the properties marked as `[FromRoute]` or `[FromQueryString]` must match the route data names or query string keys names. The name for the body, or form, property is irrelevant.
@@ -105,17 +105,36 @@ Once the models are defined they can be used as follows:
 <a id='snippet-model-binding-bind-body-and-route-data'></a>
 ```cs
 [HttpPost("/sample/{id}")]
+[BindFromBody<BodyModel>]
+[BindFromRoute<int>(routeValueKey: "id")]
+public Task Handle(HttpRequest request)
+{
+    var ctx = request.GetCompositionContext();
+    var arguments = ctx.GetArguments(GetType());
+    
+    var body = arguments.Argument<BodyModel>();
+    var id = arguments.Argument<int>("id");
+
+    //use values as needed
+    
+    return Task.CompletedTask;
+}
+```
+<sup><a href='/src/Snippets/ModelBinding/DeclarativeModelBinding.cs#L11-L27' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-bind-body-and-route-data' title='Start of snippet'>anchor</a></sup>
+<a id='snippet-model-binding-bind-body-and-route-data-1'></a>
+```cs
+[HttpPost("/sample/{id}")]
 public async Task Handle(HttpRequest request)
 {
     var requestModel = await request.Bind<RequestModel>();
     var body = requestModel.Body;
     var aString = body.AString;
-    var id = requestModel.id;
+    var id = requestModel.Id;
 
     //use values as needed
 }
 ```
-<sup><a href='/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs#L25-L36' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-bind-body-and-route-data' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs#L10-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-bind-body-and-route-data-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 For more information and options when using model binding refer to the [Microsoft official documentation](https://docs.microsoft.com/en-us/aspnet/core/mvc/models/model-binding?view=aspnetcore-5.0).
@@ -136,7 +155,7 @@ public async Task Handle(HttpRequest request)
     //use values as needed
 }
 ```
-<sup><a href='/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs#L41-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-try-bind' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs#L26-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-try-bind' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The `TryBind` return value is a tuple containing the binding result (the model), a boolena detailing if the model was set or not (useful to distinguish between a model binder which does not find a value and the case where a model binder sets the `null` value), and the `ModelStateDictionary` to access binding errors.

--- a/docs/model-binding.md
+++ b/docs/model-binding.md
@@ -140,3 +140,9 @@ public async Task Handle(HttpRequest request)
 <!-- endSnippet -->
 
 The `TryBind` return value is a tuple containing the binding result (the model), a boolena detailing if the model was set or not (useful to distinguish between a model binder which does not find a value and the case where a model binder sets the `null` value), and the `ModelStateDictionary` to access binding errors.
+
+## Declarative Model Binding
+
+### Named arguments experimental API
+
+The API to search for arguments exposed by the composition context is experimental and as such subject to change. The `GetArguments(Type)` method is decorated with the `Expreimental` attribute and will raise a `SC0001` warning. The warning can be suppressed with a regular pragma directive, e.g., `#pragma warning disable SC0001`.

--- a/docs/model-binding.md
+++ b/docs/model-binding.md
@@ -139,13 +139,13 @@ public async Task Handle(HttpRequest request)
 <sup><a href='/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs#L26-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-model-binding-try-bind' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The `TryBind` return value is a tuple containing the binding result (the model), a boolena detailing if the model was set or not (useful to distinguish between a model binder which does not find a value and the case where a model binder sets the `null` value), and the `ModelStateDictionary` to access binding errors.
+The `TryBind` return value is a tuple containing the binding result (the model), a boolean detailing if the model was set or not (useful to distinguish between a model binder which does not find a value and the case where a model binder sets the `null` value), and the `ModelStateDictionary` to access binding errors.
 
 ## Declarative Model Binding
 
 _Available starting with v4.1.0_
 
-Instead of directly using the `Bind`/`TryBind` API to exercise the model binding engine, it is possible to use a set of `Bind*` attributes to declare the models the composition handlers wants to bind. The following snippet demonstrates a compositin handler that declares the binding to two models:
+Instead of directly using the `Bind`/`TryBind` API to exercise the model binding engine, it is possible to use a set of `Bind*` attributes to declare the models the composition handlers wants to bind. The following snippet demonstrates a composition handler that declares the binding to two models:
 
 <!-- snippet: declarative-model-binding -->
 <a id='snippet-declarative-model-binding'></a>
@@ -171,20 +171,22 @@ Declarative model binding supports a number of binding sources through the follo
 - `BindFromFormAttribute<T>`: Binds the given type T to the incoming form fields collection. If the optional `formFieldName` is specified the binding operation only takes into account the specified form field as binding source; otherwise, the binding operation expects to bind to a `IFormCollection` type.
 - `BindAttribute<T>`: Binds the given type T from multiple sources. Each T type property can specify the source to use using the various `FromBody`, `FromForm`, `FromRoute`, etc., default ASP.Net binding attributes.
 
-Once model binding is declared, the biund models are accesible from the `ICompositionContext` arguments API, as demonstrated by the following snippet:
+Once model binding is declared, the bound models are accessible from the `ICompositionContext` arguments API, as demonstrated by the following snippet:
 
 <!-- snippet: arguments-search-api -->
 <a id='snippet-arguments-search-api'></a>
 ```cs
 var ctx = request.GetCompositionContext();
-var arguments = ctx.GetArguments(GetType());
+var arguments = ctx.GetArguments(this);
 var findValueByType = arguments.Argument<BodyModel>();
 var findValueByTypeAndName = arguments.Argument<int>(name: "id");
 var findValueByTypeAndSource = arguments.Argument<int>(bindingSource: BindingSource.Header);
 var findValueByTypeSourceAndName = arguments.Argument<string>(name: "user", bindingSource: BindingSource.Query);
 ```
-<sup><a href='/src/Snippets/ModelBinding/ArgumentsSearchAPI.cs#L12-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-arguments-search-api' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/ModelBinding/ArgumentsSearchAPI.cs#L13-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-arguments-search-api' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
+
+Arguments are segregated by component, to access them the arguments owner instance must be passed to the `GetArguments(owner)` method. Owners are restricted to a limited set of types: `ICompositionRequestsHandler`, `ICompositionEventsSubscriber`, and `ICompositionEventsHandler<T>`. 
 
 ### Named arguments experimental API
 

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -97,7 +97,13 @@ namespace ServiceComposer.AspNetCore
         string RequestId { get; }
         [System.Diagnostics.CodeAnalysis.Experimental("SC0001", UrlFormat=("https://github.com/ServiceComposer/ServiceComposer.AspNetCore/blob/master/docs/mo" +
             "del-binding.md#named-arguments-experimental-api?id={0}"))]
-        System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? GetArguments(System.Type owningComponentType);
+        System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? GetArguments(ServiceComposer.AspNetCore.ICompositionEventsSubscriber owner);
+        [System.Diagnostics.CodeAnalysis.Experimental("SC0001", UrlFormat=("https://github.com/ServiceComposer/ServiceComposer.AspNetCore/blob/master/docs/mo" +
+            "del-binding.md#named-arguments-experimental-api?id={0}"))]
+        System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? GetArguments(ServiceComposer.AspNetCore.ICompositionRequestsHandler owner);
+        [System.Diagnostics.CodeAnalysis.Experimental("SC0001", UrlFormat=("https://github.com/ServiceComposer/ServiceComposer.AspNetCore/blob/master/docs/mo" +
+            "del-binding.md#named-arguments-experimental-api?id={0}"))]
+        System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? GetArguments<T>(ServiceComposer.AspNetCore.ICompositionEventsHandler<T> owner);
         System.Threading.Tasks.Task RaiseEvent<TEvent>(TEvent @event);
     }
     public interface ICompositionErrorsHandler

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -95,6 +95,8 @@ namespace ServiceComposer.AspNetCore
     public interface ICompositionContext
     {
         string RequestId { get; }
+        [System.Diagnostics.CodeAnalysis.Experimental("SC0001")]
+        System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? GetArguments(System.Type owningComponentType);
         System.Threading.Tasks.Task RaiseEvent<TEvent>(TEvent @event);
     }
     public interface ICompositionErrorsHandler
@@ -134,6 +136,20 @@ namespace ServiceComposer.AspNetCore
     public interface IViewModelPreviewHandler
     {
         System.Threading.Tasks.Task Preview(Microsoft.AspNetCore.Http.HttpRequest request);
+    }
+    public class ModelBindingArgument
+    {
+        public ModelBindingArgument(string name, object? value, Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource bindingSource) { }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource BindingSource { get; }
+        public string Name { get; }
+        public object? Value { get; }
+    }
+    public static class ModelBindingArgumentExtensions
+    {
+        public static TArgument? Argument<TArgument>(this System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? arguments) { }
+        public static TArgument? Argument<TArgument>(this System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? arguments, Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource bindingSource) { }
+        public static TArgument? Argument<TArgument>(this System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? arguments, string name) { }
+        public static TArgument? Argument<TArgument>(this System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? arguments, string name, Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource bindingSource) { }
     }
     public enum ResponseCasing
     {

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -98,6 +98,22 @@ namespace ServiceComposer.AspNetCore
     {
         System.Threading.Tasks.Task Preview(Microsoft.AspNetCore.Http.HttpRequest request);
     }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method)]
+    public class ModelAttribute : System.Attribute
+    {
+        public ModelAttribute(System.Type type, ServiceComposer.AspNetCore.ModelBindingSource bindingSource = 0) { }
+        public ServiceComposer.AspNetCore.ModelBindingSource Source { get; }
+        public System.Type Type { get; }
+    }
+    public enum ModelBindingSource
+    {
+        ModelBinding = 0,
+        Query = 1,
+        Route = 2,
+        Body = 3,
+        Form = 4,
+        Headers = 5,
+    }
     public enum ResponseCasing
     {
         CamelCase = 0,

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -29,11 +29,6 @@ namespace ServiceComposer.AspNetCore
         public BindFromFormAttribute(string? formFieldName = null) { }
         public override string ModelName { get; }
     }
-    public sealed class BindFromHeaderAttribute<T> : ServiceComposer.AspNetCore.BindModelAttribute
-    {
-        public BindFromHeaderAttribute(string headerName) { }
-        public override string ModelName { get; }
-    }
     public sealed class BindFromQueryAttribute<T> : ServiceComposer.AspNetCore.BindModelAttribute
     {
         public BindFromQueryAttribute(string queryParameterName) { }

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -68,6 +68,10 @@ namespace ServiceComposer.AspNetCore
     {
         public static Microsoft.AspNetCore.Builder.IEndpointConventionBuilder MapCompositionHandlers(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints) { }
     }
+    public static class HttpContextExtensions
+    {
+        public static string EnsureRequestIdIsSetup(this Microsoft.AspNetCore.Http.HttpContext context) { }
+    }
     public static class HttpRequestExtensions
     {
         [return: System.Runtime.CompilerServices.Dynamic]

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -95,7 +95,8 @@ namespace ServiceComposer.AspNetCore
     public interface ICompositionContext
     {
         string RequestId { get; }
-        [System.Diagnostics.CodeAnalysis.Experimental("SC0001")]
+        [System.Diagnostics.CodeAnalysis.Experimental("SC0001", UrlFormat=("https://github.com/ServiceComposer/ServiceComposer.AspNetCore/blob/master/docs/mo" +
+            "del-binding.md#named-arguments-experimental-api?id={0}"))]
         System.Collections.Generic.IList<ServiceComposer.AspNetCore.ModelBindingArgument>? GetArguments(System.Type owningComponentType);
         System.Threading.Tasks.Task RaiseEvent<TEvent>(TEvent @event);
     }

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -14,30 +14,43 @@ namespace ServiceComposer.AspNetCore
             Include = 1,
         }
     }
-    public sealed class BindFromBodyAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    public sealed class BindAttribute<T> : ServiceComposer.AspNetCore.BindModelAttribute
+    {
+        public BindAttribute() { }
+        public override string ModelName { get; }
+    }
+    public sealed class BindFromBodyAttribute<T> : ServiceComposer.AspNetCore.BindModelAttribute
     {
         public BindFromBodyAttribute() { }
         public override string ModelName { get; }
     }
-    public sealed class BindFromFormAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    public sealed class BindFromFormAttribute<T> : ServiceComposer.AspNetCore.BindModelAttribute
     {
-        public BindFromFormAttribute(string formFieldName) { }
+        public BindFromFormAttribute(string? formFieldName = null) { }
         public override string ModelName { get; }
     }
-    public sealed class BindFromHeaderAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    public sealed class BindFromHeaderAttribute<T> : ServiceComposer.AspNetCore.BindModelAttribute
     {
         public BindFromHeaderAttribute(string headerName) { }
         public override string ModelName { get; }
     }
-    public sealed class BindFromQueryAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    public sealed class BindFromQueryAttribute<T> : ServiceComposer.AspNetCore.BindModelAttribute
     {
         public BindFromQueryAttribute(string queryParameterName) { }
         public override string ModelName { get; }
     }
-    public sealed class BindFromRouteAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    public sealed class BindFromRouteAttribute<T> : ServiceComposer.AspNetCore.BindModelAttribute
     {
         public BindFromRouteAttribute(string routeValueKey) { }
         public override string ModelName { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
+    public abstract class BindModelAttribute : System.Attribute
+    {
+        protected BindModelAttribute(System.Type type, Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource bindingSource) { }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource BindingSource { get; }
+        public abstract string ModelName { get; }
+        public System.Type Type { get; }
     }
     public static class ComposedRequestIdHeader
     {
@@ -122,14 +135,6 @@ namespace ServiceComposer.AspNetCore
     public interface IViewModelPreviewHandler
     {
         System.Threading.Tasks.Task Preview(Microsoft.AspNetCore.Http.HttpRequest request);
-    }
-    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
-    public abstract class ModelAttribute : System.Attribute
-    {
-        protected ModelAttribute(System.Type type, Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource bindingSource) { }
-        public Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource BindingSource { get; }
-        public abstract string ModelName { get; }
-        public System.Type Type { get; }
     }
     public enum ResponseCasing
     {

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -14,14 +14,29 @@ namespace ServiceComposer.AspNetCore
             Include = 1,
         }
     }
-    public sealed class BindModelFromBodyAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    public sealed class BindFromBodyAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
     {
-        public BindModelFromBodyAttribute() { }
+        public BindFromBodyAttribute() { }
         public override string ModelName { get; }
     }
-    public sealed class BindModelFromRouteAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    public sealed class BindFromFormAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
     {
-        public BindModelFromRouteAttribute(string routeValueKey) { }
+        public BindFromFormAttribute(string formFieldName) { }
+        public override string ModelName { get; }
+    }
+    public sealed class BindFromHeaderAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    {
+        public BindFromHeaderAttribute(string headerName) { }
+        public override string ModelName { get; }
+    }
+    public sealed class BindFromQueryAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    {
+        public BindFromQueryAttribute(string queryParameterName) { }
+        public override string ModelName { get; }
+    }
+    public sealed class BindFromRouteAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    {
+        public BindFromRouteAttribute(string routeValueKey) { }
         public override string ModelName { get; }
     }
     public static class ComposedRequestIdHeader

--- a/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
+++ b/src/ServiceComposer.AspNetCore.Tests/API/APIApprovals.Approve_API.verified.txt
@@ -14,6 +14,16 @@ namespace ServiceComposer.AspNetCore
             Include = 1,
         }
     }
+    public sealed class BindModelFromBodyAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    {
+        public BindModelFromBodyAttribute() { }
+        public override string ModelName { get; }
+    }
+    public sealed class BindModelFromRouteAttribute<T> : ServiceComposer.AspNetCore.ModelAttribute
+    {
+        public BindModelFromRouteAttribute(string routeValueKey) { }
+        public override string ModelName { get; }
+    }
     public static class ComposedRequestIdHeader
     {
         public const string Key = "composed-request-id";
@@ -98,21 +108,13 @@ namespace ServiceComposer.AspNetCore
     {
         System.Threading.Tasks.Task Preview(Microsoft.AspNetCore.Http.HttpRequest request);
     }
-    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method)]
-    public class ModelAttribute : System.Attribute
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
+    public abstract class ModelAttribute : System.Attribute
     {
-        public ModelAttribute(System.Type type, ServiceComposer.AspNetCore.ModelBindingSource bindingSource = 0) { }
-        public ServiceComposer.AspNetCore.ModelBindingSource Source { get; }
+        protected ModelAttribute(System.Type type, Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource bindingSource) { }
+        public Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource BindingSource { get; }
+        public abstract string ModelName { get; }
         public System.Type Type { get; }
-    }
-    public enum ModelBindingSource
-    {
-        ModelBinding = 0,
-        Query = 1,
-        Route = 2,
-        Body = 3,
-        Form = 4,
-        Headers = 5,
     }
     public enum ResponseCasing
     {

--- a/src/ServiceComposer.AspNetCore.Tests/When_assembly_scanning.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_assembly_scanning.cs
@@ -15,10 +15,7 @@ namespace ServiceComposer.AspNetCore.Tests
         class SampleNeverInvokedHandler : ICompositionRequestsHandler
         {
             [HttpGet("/this-doesnt-exist")]
-            public Task Handle(HttpRequest request)
-            {
-                throw new NotImplementedException();
-            }
+            public Task Handle(HttpRequest request) => Task.CompletedTask;
         }
 
         [Fact]

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using ServiceComposer.AspNetCore.Testing;
 using Xunit;
 
@@ -29,7 +28,7 @@ namespace ServiceComposer.AspNetCore.Tests
                 var vm = request.GetComposedResponseModel();
                 var ctx = request.GetCompositionContext();
                 vm.RequestId = ctx.RequestId;
-                
+
                 return Task.CompletedTask;
             }
         }

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding.cs
@@ -1,0 +1,107 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Tests
+{
+    public class When_using_declarative_model_binding
+    {
+        class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
+        {
+            [HttpPost("/empty-response/{id}")]
+            [BindModelFromBody<MyClass>]
+            [BindModelFromRoute<int>(routeValueKey: "id")]
+            public Task Handle(HttpRequest request)
+            {
+                var vm = request.GetComposedResponseModel();
+                var ctx = request.GetCompositionContext();
+                vm.RequestId = ctx.RequestId;
+                
+                return Task.CompletedTask;
+            }
+        }
+
+        class MyClass
+        {
+            public required string Text { get; init; }
+        }
+
+        class CaptureArgumentsEndpointFilter : IEndpointFilter
+        {
+            public IList<object?> CapturedArguments { get; private set; } = null!;
+
+            public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+            {
+                CapturedArguments = context.Arguments;
+                return await next(context);
+            }
+        }
+        
+        [Fact]
+        public async Task Should_populate_arguments_as_expected()
+        {
+            var expectedComposedRequestId = Guid.NewGuid().ToString();
+            var captureArgumentsEndpointFilter = new CaptureArgumentsEndpointFilter();
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_endpoint_filters>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.ResponseSerialization.DefaultResponseCasing = ResponseCasing.PascalCase;
+                        options.RegisterCompositionHandler<ResponseHandlerWithModelBinding>();
+                    });
+                    services.AddRouting();
+                    services.AddControllers();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder =>
+                    {
+                        builder.MapCompositionHandlers()
+                            .AddEndpointFilter(captureArgumentsEndpointFilter);
+                    });
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("composed-request-id", expectedComposedRequestId);
+
+            var json = JsonConvert.SerializeObject(new MyClass(){ Text = "some text" });
+            var stringContent = new StringContent(json, Encoding.UTF8, MediaTypeNames.Application.Json);
+            stringContent.Headers.ContentLength = json.Length;
+            
+            // Act
+            var response = await client.PostAsync("/empty-response/1", stringContent);
+
+            Assert.True(response.IsSuccessStatusCode);
+            
+            var arguments = captureArgumentsEndpointFilter.CapturedArguments;
+            Assert.NotNull(arguments);
+            Assert.True(arguments.Count == 2);
+            
+            var myClass = arguments.OfType<MyClass>().Single();
+            Assert.Equal("some text", myClass.Text);
+        }
+        
+        // TODO: test using multiple Model attributes
+        // TODO: test using value types
+        // TODO: test using different biding sources
+    }
+}

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding.cs
@@ -21,8 +21,8 @@ namespace ServiceComposer.AspNetCore.Tests
         class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
         {
             [HttpPost("/empty-response/{id}")]
-            [BindModelFromBody<MyClass>]
-            [BindModelFromRoute<int>(routeValueKey: "id")]
+            [BindFromBody<MyClass>]
+            [BindFromRoute<int>(routeValueKey: "id")]
             public Task Handle(HttpRequest request)
             {
                 var vm = request.GetComposedResponseModel();

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_body_payload.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_body_payload.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace ServiceComposer.AspNetCore.Tests
 {
-    public class When_using_declarative_model_binding
+    public class When_using_declarative_model_binding_and_body_payload
     {
         class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
         {
@@ -53,6 +53,7 @@ namespace ServiceComposer.AspNetCore.Tests
         public async Task Should_populate_arguments_as_expected()
         {
             var expectedComposedRequestId = Guid.NewGuid().ToString();
+            const string expectedText = "some text";
             var captureArgumentsEndpointFilter = new CaptureArgumentsEndpointFilter();
 
             // Arrange
@@ -82,11 +83,10 @@ namespace ServiceComposer.AspNetCore.Tests
 
             client.DefaultRequestHeaders.Add("composed-request-id", expectedComposedRequestId);
 
-            var json = JsonConvert.SerializeObject(new MyClass(){ Text = "some text" });
+            // Act
+            var json = JsonConvert.SerializeObject(new MyClass(){ Text = expectedText });
             var stringContent = new StringContent(json, Encoding.UTF8, MediaTypeNames.Application.Json);
             stringContent.Headers.ContentLength = json.Length;
-            
-            // Act
             var response = await client.PostAsync("/empty-response/1", stringContent);
 
             Assert.True(response.IsSuccessStatusCode);
@@ -96,11 +96,7 @@ namespace ServiceComposer.AspNetCore.Tests
             Assert.True(arguments.Count == 2);
             
             var myClass = arguments.OfType<MyClass>().Single();
-            Assert.Equal("some text", myClass.Text);
+            Assert.Equal(expectedText, myClass.Text);
         }
-        
-        // TODO: test using multiple Model attributes
-        // TODO: test using value types
-        // TODO: test using different biding sources
     }
 }

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_form_payload.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_form_payload.cs
@@ -102,9 +102,5 @@ namespace ServiceComposer.AspNetCore.Tests
             Assert.Equal(expectedText, myClass.Text);
             Assert.Equal(expectedNumber, myClass.Number);
         }
-        
-        // TODO: test using multiple Model attributes
-        // TODO: test using value types
-        // TODO: test using different biding sources
     }
 }

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_form_payload.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_form_payload.cs
@@ -1,0 +1,110 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Tests
+{
+    public class When_using_declarative_model_binding_and_form_payload
+    {
+        class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
+        {
+            [HttpPost("/empty-response/{id}")]
+            [BindFromForm<MyClass>()]
+            [BindFromRoute<int>(routeValueKey: "id")]
+            public Task Handle(HttpRequest request)
+            {
+                var vm = request.GetComposedResponseModel();
+                var ctx = request.GetCompositionContext();
+                vm.RequestId = ctx.RequestId;
+
+                return Task.CompletedTask;
+            }
+        }
+
+        class MyClass
+        {
+            public required int Number { get; init; }
+            public required string Text { get; init; }
+        }
+
+        class CaptureArgumentsEndpointFilter : IEndpointFilter
+        {
+            public IList<object?> CapturedArguments { get; private set; } = null!;
+
+            public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+            {
+                CapturedArguments = context.Arguments;
+                return await next(context);
+            }
+        }
+        
+        [Fact]
+        public async Task Should_populate_arguments_as_expected()
+        {
+            var expectedComposedRequestId = Guid.NewGuid().ToString();
+            const string expectedText = "some text";
+            const int expectedNumber = 42;
+            var captureArgumentsEndpointFilter = new CaptureArgumentsEndpointFilter();
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_endpoint_filters>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.ResponseSerialization.DefaultResponseCasing = ResponseCasing.PascalCase;
+                        options.RegisterCompositionHandler<ResponseHandlerWithModelBinding>();
+                    });
+                    services.AddRouting();
+                    services.AddControllers();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder =>
+                    {
+                        builder.MapCompositionHandlers()
+                            .AddEndpointFilter(captureArgumentsEndpointFilter);
+                    });
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("composed-request-id", expectedComposedRequestId);
+
+            // Act
+            var formData = new FormUrlEncodedContent([
+                new KeyValuePair<string, string>("text", expectedText),
+                new KeyValuePair<string, string>("number", expectedNumber.ToString())
+            ]);
+            var response = await client.PostAsync("/empty-response/1", formData);
+
+            Assert.True(response.IsSuccessStatusCode);
+            
+            var arguments = captureArgumentsEndpointFilter.CapturedArguments;
+            Assert.NotNull(arguments);
+            Assert.True(arguments.Count == 2);
+            
+            var myClass = arguments.OfType<MyClass>().Single();
+            Assert.Equal(expectedText, myClass.Text);
+            Assert.Equal(expectedNumber, myClass.Number);
+        }
+        
+        // TODO: test using multiple Model attributes
+        // TODO: test using value types
+        // TODO: test using different biding sources
+    }
+}

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_multiple_binding_sources_and_body_payload.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_multiple_binding_sources_and_body_payload.cs
@@ -30,7 +30,7 @@ namespace ServiceComposer.AspNetCore.Tests
                 vm.RequestId = ctx.RequestId;
                 
 #pragma warning disable SC0001
-                var myClass = ctx.GetArguments(GetType()).Argument<MyClass>();
+                var myClass = ctx.GetArguments(this).Argument<MyClass>();
                 vm.NumberFromHeader = myClass?.Number;
                 vm.SomeTextFromComplexType = myClass?.AComplexType.SomeText;
 #pragma warning restore SC0001

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_multiple_binding_sources_and_body_payload.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_multiple_binding_sources_and_body_payload.cs
@@ -1,0 +1,121 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Tests
+{
+    public class When_using_declarative_model_binding_and_multiple_binding_sources_and_body_payload
+    {
+        class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
+        {
+            [HttpPost("/empty-response/{id}")]
+            [Bind<MyClass>()]
+            public Task Handle(HttpRequest request)
+            {
+                var vm = request.GetComposedResponseModel();
+                var ctx = request.GetCompositionContext();
+                vm.RequestId = ctx.RequestId;
+
+                return Task.CompletedTask;
+            }
+        }
+
+        class MyClass
+        {
+            [FromRoute(Name = "id")]
+            public required int Identifier { get; init; }
+
+            [FromHeader(Name = "X-Number")]
+            public required int Number { get; init; }
+
+            [FromBody]
+            public required ComplexType AComplexType { get; init; }
+        }
+
+        class ComplexType
+        {
+            public required string SomeText { get; init; }
+            public required string SomeMoreText { get; init; }
+        }
+
+        class CaptureArgumentsEndpointFilter : IEndpointFilter
+        {
+            public IList<object?> CapturedArguments { get; private set; } = null!;
+
+            public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+            {
+                CapturedArguments = context.Arguments;
+                return await next(context);
+            }
+        }
+        
+        [Fact]
+        public async Task Should_populate_arguments_as_expected()
+        {
+            var expectedComposedRequestId = Guid.NewGuid().ToString();
+            const string expectedComplexTypeSomeText = "complex type some text";
+            const string expectedComplexTypeSomeMoreText = "complex type some more text";
+            const int expectedNumber = 42;
+            var captureArgumentsEndpointFilter = new CaptureArgumentsEndpointFilter();
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_endpoint_filters>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.ResponseSerialization.DefaultResponseCasing = ResponseCasing.PascalCase;
+                        options.RegisterCompositionHandler<ResponseHandlerWithModelBinding>();
+                    });
+                    services.AddRouting();
+                    services.AddControllers();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder =>
+                    {
+                        builder.MapCompositionHandlers()
+                            .AddEndpointFilter(captureArgumentsEndpointFilter);
+                    });
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("composed-request-id", expectedComposedRequestId);
+            client.DefaultRequestHeaders.Add("X-Number", expectedNumber.ToString());
+            
+            // Act
+            var json = JsonConvert.SerializeObject(new ComplexType(){ SomeText = expectedComplexTypeSomeText, SomeMoreText = expectedComplexTypeSomeMoreText});
+            var jsonContent = new StringContent(json, Encoding.UTF8, MediaTypeNames.Application.Json);
+            jsonContent.Headers.ContentLength = json.Length;
+
+            var response = await client.PostAsync("/empty-response/1", jsonContent);
+
+            Assert.True(response.IsSuccessStatusCode);
+            
+            var arguments = captureArgumentsEndpointFilter.CapturedArguments;
+            Assert.NotNull(arguments);
+            Assert.True(arguments.Count == 1);
+            
+            var myClass = arguments.OfType<MyClass>().Single();
+            Assert.Equal(1, myClass.Identifier);
+            Assert.Equal(expectedNumber, myClass.Number);
+            Assert.Equal(expectedComplexTypeSomeText, myClass.AComplexType.SomeText);
+            Assert.Equal(expectedComplexTypeSomeMoreText, myClass.AComplexType.SomeMoreText);
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_multiple_binding_sources_and_form_data.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_declarative_model_binding_and_multiple_binding_sources_and_form_data.cs
@@ -1,0 +1,134 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Tests
+{
+    public class When_using_declarative_model_binding_and_multiple_binding_sources_and_form_data
+    {
+        class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
+        {
+            [HttpPost("/empty-response/{id}")]
+            [Bind<MyClass>()]
+            public Task Handle(HttpRequest request)
+            {
+                var vm = request.GetComposedResponseModel();
+                var ctx = request.GetCompositionContext();
+                vm.RequestId = ctx.RequestId;
+
+                return Task.CompletedTask;
+            }
+        }
+
+        class MyClass
+        {
+            [FromRoute(Name = "id")]
+            public required int Identifier { get; init; }
+
+            [FromForm(Name = "text")]
+            public required string Text { get; init; }
+            
+            [FromHeader(Name = "X-Number")]
+            public required int Number { get; init; }
+
+            [FromForm(Name = "json_data")]
+            public required IFormCollection AComplexType { get; init; }
+        }
+
+        class ComplexType
+        {
+            public required string SomeText { get; init; }
+            public required string SomeMoreText { get; init; }
+        }
+
+        class CaptureArgumentsEndpointFilter : IEndpointFilter
+        {
+            public IList<object?> CapturedArguments { get; private set; } = null!;
+
+            public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+            {
+                CapturedArguments = context.Arguments;
+                return await next(context);
+            }
+        }
+        
+        [Fact]
+        public async Task Should_populate_arguments_as_expected()
+        {
+            var expectedComposedRequestId = Guid.NewGuid().ToString();
+            const string expectedText = "some text";
+            const string expectedComplexTypeSomeText = "complex type some text";
+            const string expectedComplexTypeSomeMoreText = "complex type some more text";
+            const int expectedNumber = 42;
+            var captureArgumentsEndpointFilter = new CaptureArgumentsEndpointFilter();
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_endpoint_filters>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.ResponseSerialization.DefaultResponseCasing = ResponseCasing.PascalCase;
+                        options.RegisterCompositionHandler<ResponseHandlerWithModelBinding>();
+                    });
+                    services.AddRouting();
+                    services.AddControllers();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder =>
+                    {
+                        builder.MapCompositionHandlers()
+                            .AddEndpointFilter(captureArgumentsEndpointFilter);
+                    });
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("composed-request-id", expectedComposedRequestId);
+            client.DefaultRequestHeaders.Add("X-Number", expectedNumber.ToString());
+            
+            // Act
+            using var multipartContent = new MultipartFormDataContent();
+            multipartContent.Add(new StringContent(expectedText), "text");
+            
+            var json = JsonConvert.SerializeObject(new ComplexType(){ SomeText = expectedComplexTypeSomeText, SomeMoreText = expectedComplexTypeSomeMoreText});
+            var jsonContent = new StringContent(json, Encoding.UTF8, MediaTypeNames.Application.Json);
+            jsonContent.Headers.ContentLength = json.Length;
+            
+            multipartContent.Add(jsonContent, "json_data");
+
+            var response = await client.PostAsync("/empty-response/1", multipartContent);
+
+            Assert.True(response.IsSuccessStatusCode);
+            
+            var arguments = captureArgumentsEndpointFilter.CapturedArguments;
+            Assert.NotNull(arguments);
+            Assert.True(arguments.Count == 1);
+            
+            var myClass = arguments.OfType<MyClass>().Single();
+            Assert.Equal(1, myClass.Identifier);
+            Assert.Equal(expectedText, myClass.Text);
+            Assert.Equal(expectedNumber, myClass.Number);
+            
+            var complexType = JsonConvert.DeserializeObject<ComplexType>(myClass.AComplexType["json_data"].ToString());
+            
+            Assert.Equal(expectedComplexTypeSomeText, complexType?.SomeText);
+            Assert.Equal(expectedComplexTypeSomeMoreText, complexType?.SomeMoreText);
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -1,10 +1,15 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ServiceComposer.AspNetCore.Testing;
 using Xunit;
@@ -28,8 +33,6 @@ namespace ServiceComposer.AspNetCore.Tests
         
         class SampleEndpointFilter : IEndpointFilter
         {
-            public bool Invoked { get; set; }
-            public object CapturedResponse { get; set; }
             public bool Invoked { get; private set; }
             public object? CapturedResponse { get; private set; }
             
@@ -100,6 +103,99 @@ namespace ServiceComposer.AspNetCore.Tests
 
             Assert.True(anotherSampleEndpointFilter.Invoked);
             Assert.Equal(expectedComposedRequestId, (anotherSampleEndpointFilter.CapturedResponse as dynamic)?.RequestId);
+
+            var contentString = await response.Content.ReadAsStringAsync();
+            dynamic body = JObject.Parse(contentString);
+            Assert.Equal(expectedComposedRequestId, (string)body.RequestId);
+        }
+        
+        class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
+        {
+            [HttpPost("/empty-response/{id}")]
+            [Model<ModelValues>]
+            public Task Handle(HttpRequest request)
+            {
+                var vm = request.GetComposedResponseModel();
+                var ctx = request.GetCompositionContext();
+                vm.RequestId = ctx.RequestId;
+
+                return Task.CompletedTask;
+            }
+        }
+
+        class ModelValues
+        {
+            [FromRoute(Name = "id")]
+            public int Identifier { get; set; }
+            
+            [FromBody]
+            public MyClass? Body { get; set; }
+        }
+
+        class MyClass
+        {
+            public required string Text { get; set; }
+        }
+
+        class CaptureArgumentsEndpointFilter : IEndpointFilter
+        {
+            public bool Invoked { get; private set; }
+            public IList<object?> CapturedArguments { get; private set; } = null!;
+
+            public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+            {
+                Invoked = true;
+                CapturedArguments = context.Arguments;
+                return await next(context);
+            }
+        }
+        
+        [Fact]
+        public async Task Should_populate_arguments_as_expected()
+        {
+            var expectedComposedRequestId = Guid.NewGuid().ToString();
+            var captureArgumentsEndpointFilter = new CaptureArgumentsEndpointFilter();
+
+            // Arrange
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<When_using_endpoint_filters>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.ResponseSerialization.DefaultResponseCasing = ResponseCasing.PascalCase;
+                        options.RegisterCompositionHandler<ResponseHandlerWithModelBinding>();
+                    });
+                    services.AddRouting();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder =>
+                    {
+                        builder.MapCompositionHandlers()
+                            .AddEndpointFilter(captureArgumentsEndpointFilter);
+                    });
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("composed-request-id", expectedComposedRequestId);
+
+            var modelBody = new MyClass(){ Text = "some text" };
+            var json = JsonConvert.SerializeObject(modelBody);
+            var stringContent = new StringContent(json, Encoding.UTF8, MediaTypeNames.Application.Json);
+            stringContent.Headers.ContentLength = json.Length;
+            
+            // Act
+            var response = await client.PostAsync("/empty-response/1", stringContent);
+
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.True(captureArgumentsEndpointFilter.Invoked);
+            
+            var arguments = captureArgumentsEndpointFilter.CapturedArguments;
+            Assert.NotNull(arguments);
+            Assert.True(arguments.Count == 2);
 
             var contentString = await response.Content.ReadAsStringAsync();
             dynamic body = JObject.Parse(contentString);

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -113,8 +113,8 @@ namespace ServiceComposer.AspNetCore.Tests
         class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
         {
             [HttpPost("/empty-response/{id}")]
-            [BindModelFromBody<MyClass>]
-            [BindModelFromRoute<int>("id")]
+            [BindFromBody<MyClass>]
+            [BindFromRoute<int>("id")]
             public Task Handle(HttpRequest request)
             {
                 var vm = request.GetComposedResponseModel();

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -168,6 +168,7 @@ namespace ServiceComposer.AspNetCore.Tests
                         options.RegisterCompositionHandler<ResponseHandlerWithModelBinding>();
                     });
                     services.AddRouting();
+                    services.AddControllers();
                 },
                 configure: app =>
                 {

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -196,7 +196,7 @@ namespace ServiceComposer.AspNetCore.Tests
             
             var arguments = captureArgumentsEndpointFilter.CapturedArguments;
             Assert.NotNull(arguments);
-            Assert.True(arguments.Count == 2);
+            Assert.True(arguments.Count == 1);
 
             var contentString = await response.Content.ReadAsStringAsync();
             dynamic body = JObject.Parse(contentString);

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -112,7 +112,7 @@ namespace ServiceComposer.AspNetCore.Tests
         class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
         {
             [HttpPost("/empty-response/{id}")]
-            [Model<ModelValues>]
+            [Model(type: typeof(ModelValues))]
             public Task Handle(HttpRequest request)
             {
                 var vm = request.GetComposedResponseModel();

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -29,8 +30,10 @@ namespace ServiceComposer.AspNetCore.Tests
         {
             public bool Invoked { get; set; }
             public object CapturedResponse { get; set; }
+            public bool Invoked { get; private set; }
+            public object? CapturedResponse { get; private set; }
             
-            public async ValueTask<object> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+            public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
             {
                 Invoked = true;
                 CapturedResponse = await next(context);
@@ -41,10 +44,10 @@ namespace ServiceComposer.AspNetCore.Tests
         
         class AnotherSampleEndpointFilter : IEndpointFilter
         {
-            public bool Invoked { get; set; }
-            public object CapturedResponse { get; set; }
-            
-            public async ValueTask<object> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+            public bool Invoked { get; private set; }
+            public object? CapturedResponse { get; private set; }
+
+            public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
             {
                 Invoked = true;
                 CapturedResponse = await next(context);
@@ -52,7 +55,7 @@ namespace ServiceComposer.AspNetCore.Tests
                 return CapturedResponse;
             }
         }
-
+        
         [Fact]
         public async Task Should_invoke_the_filter()
         {
@@ -93,10 +96,10 @@ namespace ServiceComposer.AspNetCore.Tests
             Assert.True(response.IsSuccessStatusCode);
             
             Assert.True(sampleEndpointFilter.Invoked);
-            Assert.Equal(expectedComposedRequestId, ((dynamic)sampleEndpointFilter.CapturedResponse).RequestId);
+            Assert.Equal(expectedComposedRequestId, (sampleEndpointFilter.CapturedResponse as dynamic)?.RequestId);
 
             Assert.True(anotherSampleEndpointFilter.Invoked);
-            Assert.Equal(expectedComposedRequestId, ((dynamic)anotherSampleEndpointFilter.CapturedResponse).RequestId);
+            Assert.Equal(expectedComposedRequestId, (anotherSampleEndpointFilter.CapturedResponse as dynamic)?.RequestId);
 
             var contentString = await response.Content.ReadAsStringAsync();
             dynamic body = JObject.Parse(contentString);

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
@@ -112,7 +113,7 @@ namespace ServiceComposer.AspNetCore.Tests
         class ResponseHandlerWithModelBinding : ICompositionRequestsHandler
         {
             [HttpPost("/empty-response/{id}")]
-            [Model(type: typeof(ModelValues))]
+            [BindModelFromWrapper<ModelValues>]
             public Task Handle(HttpRequest request)
             {
                 var vm = request.GetComposedResponseModel();
@@ -199,12 +200,11 @@ namespace ServiceComposer.AspNetCore.Tests
             Assert.True(arguments.Count == 1);
 
             var contentString = await response.Content.ReadAsStringAsync();
-            dynamic body = JObject.Parse(contentString);
-            Assert.Equal(expectedComposedRequestId, (string)body.RequestId);
+            dynamic responseBody = JObject.Parse(contentString);
+            Assert.Equal(expectedComposedRequestId, (string)responseBody.RequestId);
+
+            var mv = arguments.OfType<ModelValues>().Single();
+            Assert.Equal("some text", mv?.Body?.Text);
         }
-        
-        // TODO: test using multiple Model attributes
-        // TODO: test using value types
-        // TODO: test using different biding sources
     }
 }

--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -202,5 +202,9 @@ namespace ServiceComposer.AspNetCore.Tests
             dynamic body = JObject.Parse(contentString);
             Assert.Equal(expectedComposedRequestId, (string)body.RequestId);
         }
+        
+        // TODO: test using multiple Model attributes
+        // TODO: test using value types
+        // TODO: test using different biding sources
     }
 }

--- a/src/ServiceComposer.AspNetCore/CompositionContext.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionContext.cs
@@ -49,6 +49,17 @@ namespace ServiceComposer.AspNetCore
             return Task.WhenAll(tasks);
         }
 
+        public IList<ModelBindingArgument>? GetArguments(Type owningComponentType)
+        {
+            if (usingCompositionOverControllers)
+            {
+                throw new NotSupportedException("Model binding arguments are unsupported when using composition over controllers.");
+            }
+            
+            componentsArguments.TryGetValue(owningComponentType, out var arguments);
+            return arguments;
+        }
+
         public void Subscribe<TEvent>(CompositionEventHandler<TEvent> handler)
         {
             if (!_compositionEventsSubscriptions.TryGetValue(typeof(TEvent), out var handlers))

--- a/src/ServiceComposer.AspNetCore/CompositionContext.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionContext.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +9,12 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ServiceComposer.AspNetCore
 {
-    class CompositionContext(string requestId, HttpRequest httpRequest, CompositionMetadataRegistry metadataRegistry)
+    class CompositionContext(
+        string requestId,
+        HttpRequest httpRequest,
+        CompositionMetadataRegistry metadataRegistry,
+        IDictionary<Type, IList<ModelBindingArgument>> componentsArguments,
+        bool usingCompositionOverControllers = false)
         : ICompositionContext, ICompositionEventsPublisher
     {
         readonly ConcurrentDictionary<Type, List<CompositionEventHandler<object>>> _compositionEventsSubscriptions = new();
@@ -34,7 +40,7 @@ namespace ServiceComposer.AspNetCore
 
             // not using typeof(TEvent) to prevent introducing a breaking change
             // due to the introduction of the generic TEvent parameter
-            if (_compositionEventsSubscriptions.TryGetValue(@event.GetType(), out var compositionHandlers))
+            if (_compositionEventsSubscriptions.TryGetValue(@event!.GetType(), out var compositionHandlers))
             {
                 handlers.AddRange(compositionHandlers.Cast<CompositionEventHandler<TEvent>>());
             }

--- a/src/ServiceComposer.AspNetCore/CompositionContext.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionContext.cs
@@ -49,7 +49,11 @@ namespace ServiceComposer.AspNetCore
             return Task.WhenAll(tasks);
         }
 
-        public IList<ModelBindingArgument>? GetArguments(Type owningComponentType)
+        public IList<ModelBindingArgument>? GetArguments(ICompositionRequestsHandler owner) => GetArguments(owner.GetType());
+        public IList<ModelBindingArgument>? GetArguments(ICompositionEventsSubscriber owner) => GetArguments(owner.GetType());
+        public IList<ModelBindingArgument>? GetArguments<T>(ICompositionEventsHandler<T> owner) => GetArguments(owner.GetType());
+
+        IList<ModelBindingArgument>? GetArguments(Type owningComponentType)
         {
             if (usingCompositionOverControllers)
             {

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
@@ -10,13 +10,13 @@ namespace ServiceComposer.AspNetCore;
 
 partial class CompositionEndpointBuilder
 {
-    async Task<IList<(Type ComponentType, IList<object?> Arguments)>> GetAllComponentsArguments(HttpContext context)
+    async Task<IDictionary<Type, IList<ModelBindingArgument>>> GetAllComponentsArguments(HttpContext context)
     {
-        var result = new List<(Type ComponentType, IList<object?> Arguments)>();
+        var result = new Dictionary<Type, IList<ModelBindingArgument>>();
         foreach (var componentMetadata in ComponentsMetadata)
         {
             var modelAttributes = componentMetadata.Metadata.OfType<BindModelAttribute>();
-            var arguments = new List<object?>();
+            var arguments = new List<ModelBindingArgument>();
             foreach (var modelAttribute in modelAttributes)
             {
                 // TODO: shall we cache the instance? We cannot access it earlier otherwise we need model binding support for every request even if it's not needed by user code
@@ -27,10 +27,10 @@ partial class CompositionEndpointBuilder
                     modelAttribute.ModelName ?? "",
                     modelAttribute.BindingSource);
                 //TODO: throw if binding failed
-                arguments.Add(bindingResult.Model);
+                arguments.Add(new ModelBindingArgument(modelAttribute.ModelName!, bindingResult.Model, modelAttribute.BindingSource));
             }
             
-            result.Add((componentMetadata.ComponentType, arguments));
+            result.Add(componentMetadata.ComponentType, arguments);
         }
 
         return result;

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ServiceComposer.AspNetCore;
+
+partial class CompositionEndpointBuilder
+{
+    async Task<IList<(Type ComponentType, IList<object?> Arguments)>> GetAllComponentsArguments(HttpContext context)
+    {
+        var result = new List<(Type ComponentType, IList<object?> Arguments)>();
+        foreach (var componentMetadata in ComponentsMetadata)
+        {
+            var modelAttributes = componentMetadata.Metadata.OfType<ModelAttribute>();
+            var arguments = new List<object?>();
+            foreach (var modelAttribute in modelAttributes)
+            {
+                // TODO: shall we cache the instance? We cannot access it earlier otherwise we need model binding support for every request even if it's not needed by user code
+                var binder = context.RequestServices.GetRequiredService<RequestModelBinder>();
+                var bindingResult = await binder.TryBind(modelAttribute.Type, context.Request);
+                //TODO: throw if binding failed
+                arguments.Add(bindingResult.Model);
+            }
+            
+            result.Add((componentMetadata.ComponentType, arguments));
+        }
+
+        return result;
+    }
+}

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
@@ -18,7 +18,7 @@ partial class CompositionEndpointBuilder
             var modelAttributes = componentMetadata.Metadata.OfType<BindModelAttribute>();
             
             // A component can have more than one Http* attribute
-            // If that's the case we don't want to have more than
+            // If that's the case we don't want to have more than one
             // arguments lists. Instead, we're reusing an existing one.
             if (!result.TryGetValue(componentMetadata.ComponentType, out var arguments))
             {

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
@@ -21,7 +21,11 @@ partial class CompositionEndpointBuilder
             {
                 // TODO: shall we cache the instance? We cannot access it earlier otherwise we need model binding support for every request even if it's not needed by user code
                 var binder = context.RequestServices.GetRequiredService<RequestModelBinder>();
-                var bindingResult = await binder.TryBind(modelAttribute.Type, context.Request);
+                var bindingResult = await binder.TryBind(
+                    modelAttribute.Type,
+                    context.Request,
+                    modelAttribute.ModelName ?? "",
+                    modelAttribute.BindingSource);
                 //TODO: throw if binding failed
                 arguments.Add(bindingResult.Model);
             }

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
@@ -16,7 +16,16 @@ partial class CompositionEndpointBuilder
         foreach (var componentMetadata in ComponentsMetadata)
         {
             var modelAttributes = componentMetadata.Metadata.OfType<BindModelAttribute>();
-            var arguments = new List<ModelBindingArgument>();
+            
+            // A component can have more than one Http* attribute
+            // If that's the case we don't want to have more than
+            // arguments lists. Instead, we're reusing an existing one.
+            if (!result.TryGetValue(componentMetadata.ComponentType, out var arguments))
+            {
+                arguments = new List<ModelBindingArgument>();
+                result.Add(componentMetadata.ComponentType, arguments);
+            }
+            
             foreach (var modelAttribute in modelAttributes)
             {
                 // TODO: shall we cache the instance? We cannot access it earlier otherwise we need model binding support for every request even if it's not needed by user code
@@ -29,8 +38,6 @@ partial class CompositionEndpointBuilder
                 //TODO: throw if binding failed
                 arguments.Add(new ModelBindingArgument(modelAttribute.ModelName!, bindingResult.Model, modelAttribute.BindingSource));
             }
-            
-            result.Add(componentMetadata.ComponentType, arguments);
         }
 
         return result;

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.BindingArguments.cs
@@ -15,7 +15,7 @@ partial class CompositionEndpointBuilder
         var result = new List<(Type ComponentType, IList<object?> Arguments)>();
         foreach (var componentMetadata in ComponentsMetadata)
         {
-            var modelAttributes = componentMetadata.Metadata.OfType<ModelAttribute>();
+            var modelAttributes = componentMetadata.Metadata.OfType<BindModelAttribute>();
             var arguments = new List<object?>();
             foreach (var modelAttribute in modelAttributes)
             {

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -101,9 +101,13 @@ namespace ServiceComposer.AspNetCore
                 RequestDelegate composer = async composerHttpContext => await CompositionHandler.HandleComposableRequest(composerHttpContext, componentsTypes);
                 var pipeline = cachedPipeline ?? BuildAndCacheEndpointFilterDelegatePipeline(composer, context.RequestServices);
 
-                var allComponentsArguments = await GetAllComponentsArguments(context);
-                var allArguments = allComponentsArguments.SelectMany(a => a.Arguments).ToArray();
-                EndpointFilterInvocationContext invocationContext = new DefaultEndpointFilterInvocationContext(context, allArguments);
+                var argumentsByComponent = await GetAllComponentsArguments(context);
+                var flatArguments = argumentsByComponent.SelectMany(a => a.Arguments).ToArray();
+                
+                // TODO how are arguments exposed to composition handlers?
+                // TODO Can handlers access all arguments or only the ones they declare?
+                
+                EndpointFilterInvocationContext invocationContext = new DefaultEndpointFilterInvocationContext(context, flatArguments);
                 var viewModel = await pipeline(invocationContext);
                 
                 if (viewModel != null)

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -21,6 +21,7 @@ namespace ServiceComposer.AspNetCore
         EndpointFilterDelegate cachedPipeline;
 
         public int Order { get; }
+        public IList<(Type ComponentType, IList<object> Metadata)> ComponentsMetadata { get; } = new List<(Type ComponentType, IList<object> Metadata)>();
 
         public CompositionEndpointBuilder(RoutePattern routePattern, Type[] componentsTypes, int order, ResponseCasing defaultResponseCasing, bool useOutputFormatters)
         {

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -100,8 +100,10 @@ namespace ServiceComposer.AspNetCore
                 
                 RequestDelegate composer = async composerHttpContext => await CompositionHandler.HandleComposableRequest(composerHttpContext, componentsTypes);
                 var pipeline = cachedPipeline ?? BuildAndCacheEndpointFilterDelegatePipeline(composer, context.RequestServices);
-                
-                EndpointFilterInvocationContext invocationContext = new DefaultEndpointFilterInvocationContext(context);
+
+                var allComponentsArguments = await GetAllComponentsArguments(context);
+                var allArguments = allComponentsArguments.SelectMany(a => a.Arguments).ToArray();
+                EndpointFilterInvocationContext invocationContext = new DefaultEndpointFilterInvocationContext(context, allArguments);
                 var viewModel = await pipeline(invocationContext);
                 
                 if (viewModel != null)

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -118,9 +118,6 @@ namespace ServiceComposer.AspNetCore
                 };
                 var pipeline = cachedPipeline ?? BuildAndCacheEndpointFilterDelegatePipeline(composer, context.RequestServices);
                 
-                // TODO how are arguments exposed to composition handlers?
-                // TODO Can handlers access all arguments or only the ones they declare?
-                
                 // TODO use source generators
                 // When we'll have convention-based handlers this could be
                 // source-generated to use the the most appropriate filter

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -106,9 +106,15 @@ namespace ServiceComposer.AspNetCore
                 
                 // TODO how are arguments exposed to composition handlers?
                 // TODO Can handlers access all arguments or only the ones they declare?
-                // TODO Do we need named arguments? If the route is /{tenant:int}/{id:int} when using
-                // TODO declarative model binding there would be no way to understand which one is which
+
+                // TODO Do we need named arguments?
+                // If the route is /{tenant:int}/{id:int} when using declarative model
+                // binding there would be no way to understand which one is which
                 
+                // TODO use source generators
+                // When we'll have convention-based handlers this could be
+                // source-generated to use the the most appropriate filter
+                // invocation context based on the number of arguments to bind
                 EndpointFilterInvocationContext invocationContext = new DefaultEndpointFilterInvocationContext(context, flatArguments);
                 var viewModel = await pipeline(invocationContext);
                 

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -92,6 +92,11 @@ namespace ServiceComposer.AspNetCore
         {
             RequestDelegate = async context =>
             {
+                // We need the body to be seekable otherwise if more than one
+                // composition handler tries to bind a model to the body
+                // it'll fail and only the first one succeeds
+                context.Request.EnableBuffering();
+                
                 RequestDelegate composer = async composerHttpContext => await CompositionHandler.HandleComposableRequest(composerHttpContext, componentsTypes);
                 var pipeline = cachedPipeline ?? BuildAndCacheEndpointFilterDelegatePipeline(composer, context.RequestServices);
                 

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -99,7 +99,10 @@ namespace ServiceComposer.AspNetCore
                 context.Request.EnableBuffering();
                 
                 var argumentsByComponent = await GetAllComponentsArguments(context);
-                var flatArguments = argumentsByComponent.SelectMany(a => a.Arguments).ToArray();
+                var flatArguments = argumentsByComponent
+                    .SelectMany(kvp => kvp.Value)
+                    .Select(arg=>arg.Value)
+                    .ToArray();
                 
                 RequestDelegate composer = async composerHttpContext =>
                 {
@@ -108,7 +111,8 @@ namespace ServiceComposer.AspNetCore
                     (
                         requestId,
                         composerHttpContext.Request,
-                        composerHttpContext.RequestServices.GetRequiredService<CompositionMetadataRegistry>()
+                        composerHttpContext.RequestServices.GetRequiredService<CompositionMetadataRegistry>(),
+                        argumentsByComponent
                     );
                     await CompositionHandler.HandleComposableRequest(composerHttpContext, compositionContext, componentsTypes);
                 };

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -124,7 +124,7 @@ namespace ServiceComposer.AspNetCore
                     switch (useOutputFormatters)
                     {
                         case false when containsActionResult:
-                            throw new NotSupportedException($"Setting an action result requires output formatters supports. " +
+                            throw new NotSupportedException($"Setting an action result requires output formatters support. " +
                                                             $"Enable output formatters by setting to true the {nameof(ResponseSerializationOptions.UseOutputFormatters)} " +
                                                             $"configuration property of the {nameof(ResponseSerializationOptions)} instance.");
                         case true when containsActionResult:

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -106,6 +106,8 @@ namespace ServiceComposer.AspNetCore
                 
                 // TODO how are arguments exposed to composition handlers?
                 // TODO Can handlers access all arguments or only the ones they declare?
+                // TODO Do we need named arguments? If the route is /{tenant:int}/{id:int} when using
+                // TODO declarative model binding there would be no way to understand which one is which
                 
                 EndpointFilterInvocationContext invocationContext = new DefaultEndpointFilterInvocationContext(context, flatArguments);
                 var viewModel = await pipeline(invocationContext);

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -120,10 +120,6 @@ namespace ServiceComposer.AspNetCore
                 
                 // TODO how are arguments exposed to composition handlers?
                 // TODO Can handlers access all arguments or only the ones they declare?
-
-                // TODO Do we need named arguments?
-                // If the route is /{tenant:int}/{id:int} when using declarative model
-                // binding there would be no way to understand which one is which
                 
                 // TODO use source generators
                 // When we'll have convention-based handlers this could be

--- a/src/ServiceComposer.AspNetCore/CompositionHandler.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionHandler.cs
@@ -4,7 +4,6 @@ using System;
 using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace ServiceComposer.AspNetCore
 {
@@ -12,8 +11,6 @@ namespace ServiceComposer.AspNetCore
     {
         internal static async Task<object> HandleComposableRequest(HttpContext context, Type[] componentsTypes)
         {
-            context.Request.EnableBuffering();
-
             var request = context.Request;
 
             if(!request.Headers.TryGetValue(ComposedRequestIdHeader.Key, out var requestId))

--- a/src/ServiceComposer.AspNetCore/CompositionHandler.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionHandler.cs
@@ -4,27 +4,15 @@ using System;
 using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Primitives;
 
 namespace ServiceComposer.AspNetCore
 {
     public static partial class CompositionHandler
     {
-        internal static async Task<object> HandleComposableRequest(HttpContext context, Type[] componentsTypes)
+        internal static async Task<object> HandleComposableRequest(HttpContext context, CompositionContext compositionContext, Type[] componentsTypes)
         {
             var request = context.Request;
-
-            if(!request.Headers.TryGetValue(ComposedRequestIdHeader.Key, out var requestId))
-            {
-                requestId = Guid.NewGuid().ToString();
-            }
-
-            context.Response.Headers.Append(ComposedRequestIdHeader.Key, requestId);
-            var compositionContext = new CompositionContext
-            (
-                requestId,
-                request,
-                context.RequestServices.GetRequiredService<CompositionMetadataRegistry>()
-            );
 
             object viewModel;
             var factoryType = componentsTypes.SingleOrDefault(t => typeof(IEndpointScopedViewModelFactory).IsAssignableFrom(t)) ?? typeof(IViewModelFactory);

--- a/src/ServiceComposer.AspNetCore/CompositionHandler.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionHandler.cs
@@ -14,17 +14,9 @@ namespace ServiceComposer.AspNetCore
         {
             var request = context.Request;
 
-            object viewModel;
             var factoryType = componentsTypes.SingleOrDefault(t => typeof(IEndpointScopedViewModelFactory).IsAssignableFrom(t)) ?? typeof(IViewModelFactory);
-            var viewModelFactory = (IViewModelFactory)context.RequestServices.GetService(factoryType);
-            if (viewModelFactory != null)
-            {
-                viewModel = viewModelFactory.CreateViewModel(context, compositionContext);
-            }
-            else
-            {
-                viewModel = new ExpandoObject();
-            }
+            var viewModelFactory = (IViewModelFactory)context.RequestServices.GetService(factoryType); 
+            var viewModel = viewModelFactory != null ? viewModelFactory.CreateViewModel(context, compositionContext) : new ExpandoObject();
 
             try
             {

--- a/src/ServiceComposer.AspNetCore/CompositionOverControllersActionFilter.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionOverControllersActionFilter.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ServiceComposer.AspNetCore
 {
@@ -35,8 +36,16 @@ namespace ServiceComposer.AspNetCore
                     // composition handler tries to bind a model to the body
                     // it'll fail and only the first one succeeds
                     context.HttpContext.Request.EnableBuffering();
+                    
+                    var requestId = context.HttpContext.EnsureRequestIdIsSetup();
+                    var compositionContext = new CompositionContext
+                    (
+                        requestId,
+                        context.HttpContext.Request,
+                        context.HttpContext.RequestServices.GetRequiredService<CompositionMetadataRegistry>()
+                    );
 
-                    var viewModel = await CompositionHandler.HandleComposableRequest(context.HttpContext, handlerTypes);
+                    var viewModel = await CompositionHandler.HandleComposableRequest(context.HttpContext, compositionContext, handlerTypes);
                     switch (context.Result)
                     {
                         case ViewResult viewResult when viewResult.ViewData.Model == null:

--- a/src/ServiceComposer.AspNetCore/CompositionOverControllersActionFilter.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionOverControllersActionFilter.cs
@@ -31,6 +31,11 @@ namespace ServiceComposer.AspNetCore
 
                 if (handlerTypes.Any())
                 {
+                    // We need the body to be seekable otherwise if more than one
+                    // composition handler tries to bind a model to the body
+                    // it'll fail and only the first one succeeds
+                    context.HttpContext.Request.EnableBuffering();
+
                     var viewModel = await CompositionHandler.HandleComposableRequest(context.HttpContext, handlerTypes);
                     switch (context.Result)
                     {

--- a/src/ServiceComposer.AspNetCore/CompositionOverControllersActionFilter.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionOverControllersActionFilter.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -42,7 +44,10 @@ namespace ServiceComposer.AspNetCore
                     (
                         requestId,
                         context.HttpContext.Request,
-                        context.HttpContext.RequestServices.GetRequiredService<CompositionMetadataRegistry>()
+                        context.HttpContext.RequestServices.GetRequiredService<CompositionMetadataRegistry>(),
+                        //arguments binding is unsupported when using composition over controllers
+                        new Dictionary<Type, IList<ModelBindingArgument>>(),
+                        usingCompositionOverControllers: true
                     );
 
                     var viewModel = await CompositionHandler.HandleComposableRequest(context.HttpContext, compositionContext, handlerTypes);

--- a/src/ServiceComposer.AspNetCore/EndpointsExtensions.cs
+++ b/src/ServiceComposer.AspNetCore/EndpointsExtensions.cs
@@ -239,17 +239,17 @@ namespace ServiceComposer.AspNetCore
             };
             builder.Metadata.Add(methodMetadata);
 
-            var methodAttributes = componentsGroup.SelectMany(component => component.Method.GetCustomAttributes(inherit: true));
-            foreach (var attribute in methodAttributes)
+            // builds a list of metadata for each component in this endpoint
+            foreach (var component in componentsGroup)
             {
-                builder.Metadata.Add(attribute);
+                builder.ComponentsMetadata.Add((component.ComponentType, component.Method.GetCustomAttributes(inherit: true)));
             }
-
-            // var classAttributes = componentsGroup.SelectMany(component => component.ComponentType.GetCustomAttributes(inherit: true));
-            // foreach (var attribute in classAttributes)
-            // {
-            //     builder.Metadata.Add(attribute);
-            // }
+            
+            // flattens the metadata
+            foreach (var metadata in builder.ComponentsMetadata.SelectMany(cm=>cm.Metadata))
+            {
+                builder.Metadata.Add(metadata);
+            }
 
             return builder;
         }

--- a/src/ServiceComposer.AspNetCore/HttpContextExtensions.cs
+++ b/src/ServiceComposer.AspNetCore/HttpContextExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace ServiceComposer.AspNetCore;
+
+public static class HttpContextExtensions
+{
+    public static string EnsureRequestIdIsSetup(this HttpContext context)
+    {
+        if(!context.Request.Headers.TryGetValue(ComposedRequestIdHeader.Key, out var requestId))
+        {
+            requestId = Guid.NewGuid().ToString();
+        }
+
+        context.Response.Headers.Append(ComposedRequestIdHeader.Key, requestId);
+        return requestId;
+    }
+}

--- a/src/ServiceComposer.AspNetCore/ICompositionContext.cs
+++ b/src/ServiceComposer.AspNetCore/ICompositionContext.cs
@@ -10,7 +10,14 @@ namespace ServiceComposer.AspNetCore
     {
         string RequestId { get; }
         Task RaiseEvent<TEvent>(TEvent @event);
+        
         [Experimental("SC0001", UrlFormat = "https://github.com/ServiceComposer/ServiceComposer.AspNetCore/blob/master/docs/model-binding.md#named-arguments-experimental-api?id={0}")]
-        IList<ModelBindingArgument>? GetArguments(Type owningComponentType);
+        IList<ModelBindingArgument>? GetArguments(ICompositionRequestsHandler owner);
+        
+        [Experimental("SC0001", UrlFormat = "https://github.com/ServiceComposer/ServiceComposer.AspNetCore/blob/master/docs/model-binding.md#named-arguments-experimental-api?id={0}")]
+        IList<ModelBindingArgument>? GetArguments(ICompositionEventsSubscriber owner);
+        
+        [Experimental("SC0001", UrlFormat = "https://github.com/ServiceComposer/ServiceComposer.AspNetCore/blob/master/docs/model-binding.md#named-arguments-experimental-api?id={0}")]
+        IList<ModelBindingArgument>? GetArguments<T>(ICompositionEventsHandler<T> owner);
     }
 }

--- a/src/ServiceComposer.AspNetCore/ICompositionContext.cs
+++ b/src/ServiceComposer.AspNetCore/ICompositionContext.cs
@@ -10,7 +10,7 @@ namespace ServiceComposer.AspNetCore
     {
         string RequestId { get; }
         Task RaiseEvent<TEvent>(TEvent @event);
-        [Experimental("SC0001")]
+        [Experimental("SC0001", UrlFormat = "https://github.com/ServiceComposer/ServiceComposer.AspNetCore/blob/master/docs/model-binding.md#named-arguments-experimental-api?id={0}")]
         IList<ModelBindingArgument>? GetArguments(Type owningComponentType);
     }
 }

--- a/src/ServiceComposer.AspNetCore/ICompositionContext.cs
+++ b/src/ServiceComposer.AspNetCore/ICompositionContext.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace ServiceComposer.AspNetCore
 {
@@ -6,5 +10,7 @@ namespace ServiceComposer.AspNetCore
     {
         string RequestId { get; }
         Task RaiseEvent<TEvent>(TEvent @event);
+        [Experimental("SC0001")]
+        IList<ModelBindingArgument>? GetArguments(Type owningComponentType);
     }
 }

--- a/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
@@ -62,11 +62,4 @@ public sealed class BindFromFormAttribute<T>(string? formFieldName = null)
     public override string ModelName { get; } = formFieldName ?? "";
 }
 
-// TODO Add tests for this binding source
-public sealed class BindFromHeaderAttribute<T>(string headerName)
-    : BindModelAttribute(typeof(T), BindingSource.Header)
-{
-    public override string ModelName { get; } = headerName;
-}
-
 // TODO what about FromServices?

--- a/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
@@ -43,7 +43,11 @@ public sealed class BindFromRouteAttribute<T>(string routeValueKey)
     public override string ModelName { get; } = routeValueKey;
 }
 
-// TODO Add tests for this binding source
+/// <summary>
+/// Binds a model from the request query string.
+/// </summary>
+/// <param name="queryParameterName">The query string parameter name</param>
+/// <typeparam name="T"></typeparam>
 public sealed class BindFromQueryAttribute<T>(string queryParameterName)
     : BindModelAttribute(typeof(T), BindingSource.Query)
 {
@@ -61,5 +65,3 @@ public sealed class BindFromFormAttribute<T>(string? formFieldName = null)
 {
     public override string ModelName { get; } = formFieldName ?? "";
 }
-
-// TODO what about FromServices?

--- a/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
@@ -12,12 +12,32 @@ public abstract class BindModelAttribute(Type type, BindingSource bindingSource)
     public abstract string ModelName { get; }
 }
 
+// TODO Add tests for this binding source
+/// <summary>
+/// Binds a model from multiple sources. Each model property can specify the source
+/// to use using the various FromBody, FromForm, FromRoute, etc., attributes  
+/// </summary>
+/// <typeparam name="T">The type of the model to bind to</typeparam>
+public sealed class BindAttribute<T>()
+    : BindModelAttribute(typeof(T), BindingSource.ModelBinding)
+{
+    public override string ModelName { get; } = "";
+}
+
+/// <summary>
+/// Binds a model from the request body payload
+/// </summary>
+/// <typeparam name="T">The type of the model to bind to</typeparam>
 public sealed class BindFromBodyAttribute<T>()
     : BindModelAttribute(typeof(T), BindingSource.Body)
 {
     public override string ModelName { get; } = "";
 }
 
+/// <summary>
+/// Binds a model from the request path
+/// </summary>
+/// <typeparam name="T">The type of the model to bind to</typeparam>
 public sealed class BindFromRouteAttribute<T>(string routeValueKey)
     : BindModelAttribute(typeof(T), BindingSource.Path)
 {

--- a/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
@@ -12,7 +12,6 @@ public abstract class BindModelAttribute(Type type, BindingSource bindingSource)
     public abstract string ModelName { get; }
 }
 
-// TODO Add tests for this binding source
 /// <summary>
 /// Binds a model from multiple sources. Each model property can specify the source
 /// to use using the various FromBody, FromForm, FromRoute, etc., attributes  

--- a/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 namespace ServiceComposer.AspNetCore;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
-public abstract class ModelAttribute(Type type, BindingSource bindingSource) : Attribute
+public abstract class BindModelAttribute(Type type, BindingSource bindingSource) : Attribute
 {
     public Type Type { get; } = type;
     public BindingSource BindingSource { get; } = bindingSource;
@@ -13,33 +13,33 @@ public abstract class ModelAttribute(Type type, BindingSource bindingSource) : A
 }
 
 public sealed class BindFromBodyAttribute<T>()
-    : ModelAttribute(typeof(T), BindingSource.Body)
+    : BindModelAttribute(typeof(T), BindingSource.Body)
 {
     public override string ModelName { get; } = "";
-};
+}
 
 public sealed class BindFromRouteAttribute<T>(string routeValueKey)
-    : ModelAttribute(typeof(T), BindingSource.Path)
+    : BindModelAttribute(typeof(T), BindingSource.Path)
 {
     public override string ModelName { get; } = routeValueKey;
 }
 
 // TODO Add tests for this binding source
 public sealed class BindFromQueryAttribute<T>(string queryParameterName)
-    : ModelAttribute(typeof(T), BindingSource.Query)
+    : BindModelAttribute(typeof(T), BindingSource.Query)
 {
     public override string ModelName { get; } = queryParameterName;
 }
 
 public sealed class BindFromFormAttribute<T>(string? formFieldName = null)
-    : ModelAttribute(typeof(T), BindingSource.Form)
+    : BindModelAttribute(typeof(T), BindingSource.Form)
 {
     public override string ModelName { get; } = formFieldName ?? "";
 }
 
 // TODO Add tests for this binding source
 public sealed class BindFromHeaderAttribute<T>(string headerName)
-    : ModelAttribute(typeof(T), BindingSource.Header)
+    : BindModelAttribute(typeof(T), BindingSource.Header)
 {
     public override string ModelName { get; } = headerName;
 }

--- a/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
@@ -62,3 +62,5 @@ public sealed class BindFromHeaderAttribute<T>(string headerName)
 {
     public override string ModelName { get; } = headerName;
 }
+
+// TODO what about FromServices?

--- a/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
@@ -31,7 +31,6 @@ public sealed class BindFromQueryAttribute<T>(string queryParameterName)
     public override string ModelName { get; } = queryParameterName;
 }
 
-// TODO Add tests for this binding source
 public sealed class BindFromFormAttribute<T>(string? formFieldName = null)
     : ModelAttribute(typeof(T), BindingSource.Form)
 {

--- a/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/BindModelAttribute.cs
@@ -50,6 +50,12 @@ public sealed class BindFromQueryAttribute<T>(string queryParameterName)
     public override string ModelName { get; } = queryParameterName;
 }
 
+/// <summary>
+/// Binds a model from the form fields collection
+/// </summary>
+/// <param name="formFieldName">The optional form field name;
+/// When omitted it's expected the bound type is <c>IFormCollection</c></param>
+/// <typeparam name="T"></typeparam>
 public sealed class BindFromFormAttribute<T>(string? formFieldName = null)
     : BindModelAttribute(typeof(T), BindingSource.Form)
 {

--- a/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+
+namespace ServiceComposer.AspNetCore;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class ModelAttribute<T>(ModelBindingSource bindingSource = ModelBindingSource.ModelBinding) : Attribute
+{
+    public ModelBindingSource Source { get; set; } = bindingSource;
+    //public int Order { get; set; }
+}
+
+public enum ModelBindingSource
+{
+    ModelBinding = 0,
+    Query,
+    Route,
+    Body,
+    Form,
+    Headers
+}

--- a/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
@@ -10,7 +10,6 @@ public abstract class ModelAttribute(Type type, BindingSource bindingSource) : A
     public Type Type { get; } = type;
     public BindingSource BindingSource { get; } = bindingSource;
     public abstract string ModelName { get; }
-    //public int Order { get; set; }
 }
 
 public sealed class BindFromBodyAttribute<T>()

--- a/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
@@ -16,7 +16,7 @@ public abstract class ModelAttribute(Type type, BindingSource bindingSource) : A
 public sealed class BindModelFromBodyAttribute<T>()
     : ModelAttribute(typeof(T), BindingSource.Body)
 {
-    public override string ModelName { get; } = "model";
+    public override string ModelName { get; } = "";
 };
 
 public sealed class BindModelFromRouteAttribute<T>(string routeValueKey)

--- a/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
@@ -32,10 +32,10 @@ public sealed class BindFromQueryAttribute<T>(string queryParameterName)
 }
 
 // TODO Add tests for this binding source
-public sealed class BindFromFormAttribute<T>(string formFieldName)
+public sealed class BindFromFormAttribute<T>(string? formFieldName = null)
     : ModelAttribute(typeof(T), BindingSource.Form)
 {
-    public override string ModelName { get; } = formFieldName;
+    public override string ModelName { get; } = formFieldName ?? "";
 }
 
 // TODO Add tests for this binding source

--- a/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
@@ -24,3 +24,24 @@ public sealed class BindFromRouteAttribute<T>(string routeValueKey)
 {
     public override string ModelName { get; } = routeValueKey;
 }
+
+// TODO Add tests for this binding source
+public sealed class BindFromQueryAttribute<T>(string queryParameterName)
+    : ModelAttribute(typeof(T), BindingSource.Query)
+{
+    public override string ModelName { get; } = queryParameterName;
+}
+
+// TODO Add tests for this binding source
+public sealed class BindFromFormAttribute<T>(string formFieldName)
+    : ModelAttribute(typeof(T), BindingSource.Form)
+{
+    public override string ModelName { get; } = formFieldName;
+}
+
+// TODO Add tests for this binding source
+public sealed class BindFromHeaderAttribute<T>(string headerName)
+    : ModelAttribute(typeof(T), BindingSource.Header)
+{
+    public override string ModelName { get; } = headerName;
+}

--- a/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
@@ -1,22 +1,26 @@
 #nullable enable
 using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace ServiceComposer.AspNetCore;
 
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-public class ModelAttribute(Type type, ModelBindingSource bindingSource = ModelBindingSource.ModelBinding) : Attribute
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+public abstract class ModelAttribute(Type type, BindingSource bindingSource) : Attribute
 {
-    public ModelBindingSource Source { get; } = bindingSource;
     public Type Type { get; } = type;
+    public BindingSource BindingSource { get; } = bindingSource;
+    public abstract string ModelName { get; }
     //public int Order { get; set; }
 }
 
-public enum ModelBindingSource
+public sealed class BindModelFromBodyAttribute<T>()
+    : ModelAttribute(typeof(T), BindingSource.Body)
 {
-    ModelBinding = 0,
-    Query,
-    Route,
-    Body,
-    Form,
-    Headers
+    public override string ModelName { get; } = "model";
+};
+
+public sealed class BindModelFromRouteAttribute<T>(string routeValueKey)
+    : ModelAttribute(typeof(T), BindingSource.Path)
+{
+    public override string ModelName { get; } = routeValueKey;
 }

--- a/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
@@ -4,9 +4,10 @@ using System;
 namespace ServiceComposer.AspNetCore;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-public class ModelAttribute<T>(ModelBindingSource bindingSource = ModelBindingSource.ModelBinding) : Attribute
+public class ModelAttribute(Type type, ModelBindingSource bindingSource = ModelBindingSource.ModelBinding) : Attribute
 {
-    public ModelBindingSource Source { get; set; } = bindingSource;
+    public ModelBindingSource Source { get; } = bindingSource;
+    public Type Type { get; } = type;
     //public int Order { get; set; }
 }
 

--- a/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/ModelAttribute.cs
@@ -13,13 +13,13 @@ public abstract class ModelAttribute(Type type, BindingSource bindingSource) : A
     //public int Order { get; set; }
 }
 
-public sealed class BindModelFromBodyAttribute<T>()
+public sealed class BindFromBodyAttribute<T>()
     : ModelAttribute(typeof(T), BindingSource.Body)
 {
     public override string ModelName { get; } = "";
 };
 
-public sealed class BindModelFromRouteAttribute<T>(string routeValueKey)
+public sealed class BindFromRouteAttribute<T>(string routeValueKey)
     : ModelAttribute(typeof(T), BindingSource.Path)
 {
     public override string ModelName { get; } = routeValueKey;

--- a/src/ServiceComposer.AspNetCore/ModelBinding/RequestModelBinder.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/RequestModelBinder.cs
@@ -21,8 +21,8 @@ namespace ServiceComposer.AspNetCore
             this.modelMetadataProvider = modelMetadataProvider;
             this.mvcOptions = mvcOptions;
         }
-        
-        public async Task<(T Model, bool IsModelSet, ModelStateDictionary ModelState)> TryBind<T>(HttpRequest request) where T : new ()
+
+        public async Task<(T Model, bool IsModelSet, ModelStateDictionary ModelState)> TryBind<T>(HttpRequest request)
         {
             //always rewind the stream; otherwise,
             //if multiple handlers concurrently bind
@@ -46,7 +46,7 @@ namespace ServiceComposer.AspNetCore
                 bindingInfo: null,
                 modelName: "");
 
-            modelBindingContext.Model = new T();
+            // modelBindingContext.Model = new T();
             modelBindingContext.PropertyFilter = _ => true; // All props
 
             var factoryContext = new ModelBinderFactoryContext()
@@ -66,7 +66,7 @@ namespace ServiceComposer.AspNetCore
                 .CreateBinder(factoryContext)
                 .BindModelAsync(modelBindingContext);
 
-            return ((T)modelBindingContext.Result.Model, 
+            return ((T)modelBindingContext.Result.Model,
                 modelBindingContext.Result.IsModelSet,
                 modelBindingContext.ModelState);
         }

--- a/src/ServiceComposer.AspNetCore/ModelBinding/RequestModelBinder.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBinding/RequestModelBinder.cs
@@ -39,26 +39,29 @@ namespace ServiceComposer.AspNetCore
             var valueProvider =
                 await CompositeValueProvider.CreateAsync(actionContext, mvcOptions.Value.ValueProviderFactories);
 
+            var bindingInfo = new BindingInfo()
+            {
+                BinderModelName = modelMetadata.BinderModelName,
+                BinderType = modelMetadata.BinderType,
+                BindingSource = modelMetadata.BindingSource,
+                PropertyFilterProvider = modelMetadata.PropertyFilterProvider,
+            };
+            
             var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
                 actionContext,
                 valueProvider,
                 modelMetadata,
-                bindingInfo: null,
+                bindingInfo: bindingInfo,
                 modelName: "");
 
+            // TODO remove this
             // modelBindingContext.Model = new T();
             modelBindingContext.PropertyFilter = _ => true; // All props
 
             var factoryContext = new ModelBinderFactoryContext()
             {
                 Metadata = modelMetadata,
-                BindingInfo = new BindingInfo()
-                {
-                    BinderModelName = modelMetadata.BinderModelName,
-                    BinderType = modelMetadata.BinderType,
-                    BindingSource = modelMetadata.BindingSource,
-                    PropertyFilterProvider = modelMetadata.PropertyFilterProvider,
-                },
+                BindingInfo = bindingInfo,
                 CacheToken = modelMetadata,
             };
 
@@ -71,13 +74,21 @@ namespace ServiceComposer.AspNetCore
                 modelBindingContext.ModelState);
         }
 
-        internal async Task<(object Model, bool IsModelSet, ModelStateDictionary ModelState)> TryBind(Type modelType,
-            HttpRequest request)
+        internal async Task<(object Model, bool IsModelSet, ModelStateDictionary ModelState)> TryBind(
+            Type modelType,
+            HttpRequest request,
+            string modelName,
+            BindingSource bindingSource)
         {
             //always rewind the stream; otherwise,
             //if multiple handlers concurrently bind
             //different models only the first one succeeds
             request.Body.Position = 0;
+            
+            // TODO remove this
+            // var reader = new StreamReader(request.Body);
+            // var content = await reader.ReadToEndAsync();
+            // request.Body.Position = 0;
 
             var modelMetadata = modelMetadataProvider.GetMetadataForType(modelType);
             var actionContext = new ActionContext(
@@ -88,26 +99,30 @@ namespace ServiceComposer.AspNetCore
             var valueProvider =
                 await CompositeValueProvider.CreateAsync(actionContext, mvcOptions.Value.ValueProviderFactories);
 
+            var bindingInfo = new BindingInfo()
+            {
+                BinderModelName = modelMetadata.BinderModelName,
+                BinderType = modelMetadata.BinderType,
+                BindingSource = bindingSource,
+                PropertyFilterProvider = modelMetadata.PropertyFilterProvider,
+            };
+            
             var modelBindingContext = DefaultModelBindingContext.CreateBindingContext(
                 actionContext,
                 valueProvider,
                 modelMetadata,
-                bindingInfo: null,
-                modelName: "");
+                bindingInfo: bindingInfo,
+                modelName: modelName);
 
+            // TODO remove this
             //modelBindingContext.Model = new T();
             modelBindingContext.PropertyFilter = _ => true; // All props
+            modelBindingContext.BindingSource = bindingSource;
 
             var factoryContext = new ModelBinderFactoryContext()
             {
                 Metadata = modelMetadata,
-                BindingInfo = new BindingInfo()
-                {
-                    BinderModelName = modelMetadata.BinderModelName,
-                    BinderType = modelMetadata.BinderType,
-                    BindingSource = modelMetadata.BindingSource,
-                    PropertyFilterProvider = modelMetadata.PropertyFilterProvider,
-                },
+                BindingInfo = bindingInfo,
                 CacheToken = modelMetadata,
             };
 

--- a/src/ServiceComposer.AspNetCore/ModelBindingArgument.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBindingArgument.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace ServiceComposer.AspNetCore;
+
+public class ModelBindingArgument(string name, object? value, BindingSource bindingSource)
+{
+    public string Name { get; } = name;
+    public object? Value { get; } = value;
+    public BindingSource BindingSource { get; } = bindingSource;
+}

--- a/src/ServiceComposer.AspNetCore/ModelBindingArgumentExtensions.cs
+++ b/src/ServiceComposer.AspNetCore/ModelBindingArgumentExtensions.cs
@@ -1,0 +1,61 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace ServiceComposer.AspNetCore;
+
+public static class ModelBindingArgumentExtensions
+{
+    public static TArgument? Argument<TArgument>(this IList<ModelBindingArgument>? arguments)
+    {
+        var argumentValue = arguments?.Single().Value;
+        if (argumentValue is TArgument argument)
+        {
+            return argument;
+        }
+
+        return default;
+    }
+    
+    public static TArgument? Argument<TArgument>(this IList<ModelBindingArgument>? arguments, string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        var argumentValue = arguments?.Single(a=>a.Name == name).Value;
+        if (argumentValue is TArgument argument)
+        {
+            return argument;
+        }
+
+        return default;
+    }
+    
+    public static TArgument? Argument<TArgument>(this IList<ModelBindingArgument>? arguments, BindingSource bindingSource)
+    {
+        ArgumentNullException.ThrowIfNull(bindingSource);
+
+        var argumentValue = arguments?.Single(a=>a.BindingSource == bindingSource).Value;
+        if (argumentValue is TArgument argument)
+        {
+            return argument;
+        }
+
+        return default;
+    }
+    
+    public static TArgument? Argument<TArgument>(this IList<ModelBindingArgument>? arguments, string name, BindingSource bindingSource)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(bindingSource);
+        
+        var argumentValue = arguments?.Single(a=> a.Name == name && a.BindingSource == bindingSource).Value;
+        if (argumentValue is TArgument argument)
+        {
+            return argument;
+        }
+
+        return default;
+    }
+}

--- a/src/Snippets/ModelBinding/ArgumentsSearchAPI.cs
+++ b/src/Snippets/ModelBinding/ArgumentsSearchAPI.cs
@@ -1,22 +1,28 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using ServiceComposer.AspNetCore;
 
 namespace Snippets.ModelBinding;
 
-public class ArgumentsSearchAPI
+public class ArgumentsSearchAPI : ICompositionRequestsHandler
 {
     void Snippet(HttpRequest request)
     {
 #pragma warning disable SC0001
         // begin-snippet: arguments-search-api
         var ctx = request.GetCompositionContext();
-        var arguments = ctx.GetArguments(GetType());
+        var arguments = ctx.GetArguments(this);
         var findValueByType = arguments.Argument<BodyModel>();
         var findValueByTypeAndName = arguments.Argument<int>(name: "id");
         var findValueByTypeAndSource = arguments.Argument<int>(bindingSource: BindingSource.Header);
         var findValueByTypeSourceAndName = arguments.Argument<string>(name: "user", bindingSource: BindingSource.Query);
         // end-snippet
 #pragma warning restore SC0001
+    }
+
+    public Task Handle(HttpRequest request)
+    {
+        throw new System.NotImplementedException();
     }
 }

--- a/src/Snippets/ModelBinding/ArgumentsSearchAPI.cs
+++ b/src/Snippets/ModelBinding/ArgumentsSearchAPI.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using ServiceComposer.AspNetCore;
+
+namespace Snippets.ModelBinding;
+
+public class ArgumentsSearchAPI
+{
+    void Snippet(HttpRequest request)
+    {
+#pragma warning disable SC0001
+        // begin-snippet: arguments-search-api
+        var ctx = request.GetCompositionContext();
+        var arguments = ctx.GetArguments(GetType());
+        var findValueByType = arguments.Argument<BodyModel>();
+        var findValueByTypeAndName = arguments.Argument<int>(name: "id");
+        var findValueByTypeAndSource = arguments.Argument<int>(bindingSource: BindingSource.Header);
+        var findValueByTypeSourceAndName = arguments.Argument<string>(name: "user", bindingSource: BindingSource.Query);
+        // end-snippet
+#pragma warning restore SC0001
+    }
+}

--- a/src/Snippets/ModelBinding/ArgumentsSearchAPI.cs
+++ b/src/Snippets/ModelBinding/ArgumentsSearchAPI.cs
@@ -21,8 +21,5 @@ public class ArgumentsSearchAPI : ICompositionRequestsHandler
 #pragma warning restore SC0001
     }
 
-    public Task Handle(HttpRequest request)
-    {
-        throw new System.NotImplementedException();
-    }
+    public Task Handle(HttpRequest request) => Task.CompletedTask;
 }

--- a/src/Snippets/ModelBinding/BodyModel.cs
+++ b/src/Snippets/ModelBinding/BodyModel.cs
@@ -1,0 +1,8 @@
+namespace Snippets.ModelBinding;
+
+// begin-snippet: model-binding-model
+class BodyModel
+{
+    public string AString { get; set; }
+}
+// end-snippet

--- a/src/Snippets/ModelBinding/DeclarativeModelBinding.cs
+++ b/src/Snippets/ModelBinding/DeclarativeModelBinding.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using ServiceComposer.AspNetCore;
+
+#pragma warning disable SC0001
+namespace Snippets.ModelBinding
+{
+    class DeclarativeModelBindingUsageHandler : ICompositionRequestsHandler
+    {
+        // begin-snippet: model-binding-bind-body-and-route-data
+        [HttpPost("/sample/{id}")]
+        [BindFromBody<BodyModel>]
+        [BindFromRoute<int>(routeValueKey: "id")]
+        public Task Handle(HttpRequest request)
+        {
+            var ctx = request.GetCompositionContext();
+            var arguments = ctx.GetArguments(GetType());
+            
+            var body = arguments.Argument<BodyModel>();
+            var id = arguments.Argument<int>("id");
+
+            //use values as needed
+            
+            return Task.CompletedTask;
+        }
+        // end-snippet
+    }
+}
+#pragma warning restore SC0001

--- a/src/Snippets/ModelBinding/DeclarativeModelBinding.cs
+++ b/src/Snippets/ModelBinding/DeclarativeModelBinding.cs
@@ -8,20 +8,12 @@ namespace Snippets.ModelBinding
 {
     class DeclarativeModelBindingUsageHandler : ICompositionRequestsHandler
     {
-        // begin-snippet: model-binding-bind-body-and-route-data
+        // begin-snippet: declarative-model-binding
         [HttpPost("/sample/{id}")]
         [BindFromBody<BodyModel>]
         [BindFromRoute<int>(routeValueKey: "id")]
         public Task Handle(HttpRequest request)
         {
-            var ctx = request.GetCompositionContext();
-            var arguments = ctx.GetArguments(GetType());
-            
-            var body = arguments.Argument<BodyModel>();
-            var id = arguments.Argument<int>("id");
-
-            //use values as needed
-            
             return Task.CompletedTask;
         }
         // end-snippet

--- a/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs
+++ b/src/Snippets/ModelBinding/ModelBindingUsageHandler.cs
@@ -5,21 +5,6 @@ using ServiceComposer.AspNetCore;
 
 namespace Snippets.ModelBinding
 {
-    // begin-snippet: model-binding-model
-    class BodyModel
-    {
-        public string AString { get; set; }
-    }
-    // end-snippet
-
-    // begin-snippet: model-binding-request
-    class RequestModel
-    {
-        [FromRoute] public int id { get; set; }
-        [FromBody] public BodyModel Body { get; set; }
-    }
-    // end-snippet
-
     class ModelBindingUsageHandler : ICompositionRequestsHandler
     {
         // begin-snippet: model-binding-bind-body-and-route-data
@@ -29,7 +14,7 @@ namespace Snippets.ModelBinding
             var requestModel = await request.Bind<RequestModel>();
             var body = requestModel.Body;
             var aString = body.AString;
-            var id = requestModel.id;
+            var id = requestModel.Id;
 
             //use values as needed
         }

--- a/src/Snippets/ModelBinding/RequestModel.cs
+++ b/src/Snippets/ModelBinding/RequestModel.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Snippets.ModelBinding;
+
+// begin-snippet: model-binding-request
+class RequestModel
+{
+    [FromRoute(Name = "id")] public int Id { get; set; }
+    [FromBody] public BodyModel Body { get; set; }
+}
+// end-snippet

--- a/src/TestClassLibraryWithHandlers/FakeConfig.cs
+++ b/src/TestClassLibraryWithHandlers/FakeConfig.cs
@@ -8,22 +8,16 @@ public class FakeConfig : IConfiguration
 {
     public IEnumerable<IConfigurationSection> GetChildren()
     {
-        throw new System.NotImplementedException();
+        yield return null;
     }
 
-    public IChangeToken GetReloadToken()
-    {
-        throw new System.NotImplementedException();
-    }
+    public IChangeToken GetReloadToken() => null;
 
-    public IConfigurationSection GetSection(string key)
-    {
-        throw new System.NotImplementedException();
-    }
+    public IConfigurationSection GetSection(string key) => null;
 
     public string this[string key]
     {
-        get => throw new System.NotImplementedException();
-        set => throw new System.NotImplementedException();
+        get => null;
+        set { /* NOP */ }
     }
 }


### PR DESCRIPTION
With the introduction of endpoint filters in #714, "arguments" needed to be exposed to them. In a traditional ASP.Net Core application, arguments are derived from the signature of the controller action method and later bound before invoking filters and the action method.

Currently, ServiceComposer doesn't support (yet — #247) a programming model similar to controller actions. To allow the endpoint handling logic to determine what to expose to endpoint filters, it's required to declare models using attributes on composition handlers `Handle` methods, like in the following snippet: 

```csharp
class MyHandler : ICompositionRequestsHandler
{
    [HttpPost("/address/{id}")]
    [BindFromBody<MyBody>]
    public Task Handle(HttpRequest request)
    {
        var ctx = request.GetCompositionContext();
        var body = ctx.GetArguments(GetType()).Argument<MyBody>()
        vm.RequestId = ctx.RequestId;

        return Task.CompletedTask;
    }
}
```

The above snippet uses a `BindFromBody` attribute to declare that the handler wants to bind the incoming request body to an instance of the `MyBody` type. With that declaration in place, the endpoint route handling logic will:

- Retrieve all the `Bind*` attributes from the handlers
- For each one will perform the requested binding operation
- Collect all the bound models
- Pass the bound models as arguments to the endpoint filter pipeline

Considering that binding already happened before the handler is executed, this PR also adds an experimental API to allow retrieving bound arguments from the composition context in the handler (also demonstrated in the above snippet) 

Fix #780 

## PoA

- [x] PR description
- [x] Apply labels as appropriate
- [x] tests
- [x] documentation
