### PR TITLE
Use the correct context

### DIFF
--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -106,7 +106,7 @@ namespace ServiceComposer.AspNetCore
                 
                 RequestDelegate composer = async composerHttpContext =>
                 {
-                    var requestId = context.EnsureRequestIdIsSetup();
+                    var requestId = composerHttpContext.EnsureRequestIdIsSetup();
                     var compositionContext = new CompositionContext
                     (
                         requestId,


### PR DESCRIPTION
Related to #802

Fix the CompositionEndpointBuilder to use the correct context and not the one originally passed in when the invocation happens

## PoA

- [x] PR description
- [x] Apply labels as appropriate
