### PR TITLE
Per-request composer leaked into cached endpoint pipeline

### DIFF
--- a/src/ServiceComposer.AspNetCore.Tests/CompositionHandlers/Per_request_arguments_are_not_shared.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/CompositionHandlers/Per_request_arguments_are_not_shared.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Tests.CompositionHandlers
+{
+    // Regression test: the cached endpoint filter pipeline used to capture
+    // the first request's bound arguments and reuse them on every subsequent
+    // request. A second call to the same endpoint with a different route
+    // value would see the first request's value.
+    public class Per_request_arguments_are_not_shared
+    {
+        [CompositionHandler]
+        public class EchoIdHandler(IHttpContextAccessor httpContextAccessor)
+        {
+            [HttpGet("/echo/{id}")]
+            public Task Echo(int id)
+            {
+                var vm = httpContextAccessor.HttpContext!.Request.GetComposedResponseModel();
+                vm.Id = id;
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task Two_sequential_requests_each_get_their_own_route_value()
+        {
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<Dummy>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.RegisterCompositionHandler<EchoIdHandler>();
+                        options.RegisterCompositionHandler<Generated.Per_request_arguments_are_not_shared_EchoIdHandler_Echo_int_id>();
+                    });
+                    services.AddRouting();
+                    services.AddControllers();
+                    services.AddHttpContextAccessor();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder => builder.MapCompositionHandlers());
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("Accept-Casing", "casing/pascal");
+
+            var first = await client.GetAsync("/echo/1");
+            var second = await client.GetAsync("/echo/2");
+
+            Assert.True(first.IsSuccessStatusCode);
+            Assert.True(second.IsSuccessStatusCode);
+
+            var firstId = JObject.Parse(await first.Content.ReadAsStringAsync())
+                .SelectToken("Id")?.Value<int>();
+            var secondId = JObject.Parse(await second.Content.ReadAsStringAsync())
+                .SelectToken("Id")?.Value<int>();
+
+            Assert.Equal(1, firstId);
+            Assert.Equal(2, secondId);
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.CompositionFilters.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.CompositionFilters.cs
@@ -7,7 +7,7 @@ namespace ServiceComposer.AspNetCore;
 
 partial class CompositionEndpointBuilder
 {
-   CompositionRequestFilterDelegate BuildCompositionRequestFilterDelegatePipeline(RequestDelegate composer, IServiceProvider serviceProvider)
+   CompositionRequestFilterDelegate BuildCompositionRequestFilterDelegatePipeline(IServiceProvider serviceProvider)
     {
         List<Func<CompositionRequestFilterFactoryContext, CompositionRequestFilterDelegate, CompositionRequestFilterDelegate>> compositionRequestFilterFactories = [];
         var compositionRequestFilters = Metadata
@@ -22,14 +22,17 @@ partial class CompositionEndpointBuilder
                 compositionRequestFilters.Add(typeBasedCompositionFilter);
             }
         }
-        
+
         compositionRequestFilters.ForEach(filter =>
         {
             compositionRequestFilterFactories.Add((factoryContext, next) => (context) => filter.InvokeAsync(context, next));
         });
 
+        // The composer is per-request: read it back from HttpContext.Items
+        // here so the cached pipeline does not close over a stale composer.
         CompositionRequestFilterDelegate filteredInvocation = async context =>
         {
+            var composer = (RequestDelegate)context.HttpContext.Items[CurrentComposerKey]!;
             await composer(context.HttpContext);
             var viewModel = context.HttpContext.Request.GetComposedResponseModel();
 

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.EndpointFilters.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.EndpointFilters.cs
@@ -8,11 +8,11 @@ namespace ServiceComposer.AspNetCore;
 partial class CompositionEndpointBuilder
 {
     static readonly object buildAndCacheEndpointFilterDelegatePipelineSyncLock = new ();
-    EndpointFilterDelegate BuildAndCacheEndpointFilterDelegatePipeline(RequestDelegate composer, IServiceProvider serviceProvider)
+    EndpointFilterDelegate BuildAndCacheEndpointFilterDelegatePipeline(IServiceProvider serviceProvider)
     {
         lock (buildAndCacheEndpointFilterDelegatePipelineSyncLock)
         {
-            var compositionFiltersPipeline = BuildCompositionRequestFilterDelegatePipeline(composer, serviceProvider);
+            var compositionFiltersPipeline = BuildCompositionRequestFilterDelegatePipeline(serviceProvider);
             
             var factoryContext = new EndpointFilterFactoryContext
             {

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -14,6 +14,14 @@ namespace ServiceComposer.AspNetCore
 {
     partial class CompositionEndpointBuilder : EndpointBuilder
     {
+        // The cached endpoint filter pipeline is built once per endpoint. The
+        // composer that runs at the bottom of the pipeline is per-request, so
+        // we cannot capture it in the cached delegate's closure (the cached
+        // delegate would replay the first request's bound arguments forever).
+        // Stash the per-request composer in HttpContext.Items under this key
+        // and have the innermost pipeline delegate read it back from there.
+        internal const string CurrentComposerKey = "__ServiceComposer.CurrentComposer";
+
         readonly Dictionary<ResponseCasing, JsonSerializerOptions> casingToSettingsMappings = new();
         readonly RoutePattern routePattern;
         readonly ResponseCasing defaultResponseCasing;
@@ -122,7 +130,11 @@ namespace ServiceComposer.AspNetCore
                         composerHttpContext.Request.Method, routePattern.RawText, componentsTypes.Length);
                     await CompositionHandler.HandleComposableRequest(composerHttpContext, compositionContext, componentsTypes);
                 };
-                var pipeline = cachedPipeline ?? BuildAndCacheEndpointFilterDelegatePipeline(composer, context.RequestServices);
+                // The cached pipeline reads the composer back from HttpContext.Items, so the
+                // per-request composer (and its captured argumentsByComponent) is the one
+                // that runs - not whichever composer happened to be the first one built.
+                context.Items[CurrentComposerKey] = composer;
+                var pipeline = cachedPipeline ?? BuildAndCacheEndpointFilterDelegatePipeline(context.RequestServices);
                 
                 // TODO use source generators
                 //   When we'll have convention-based handlers this could be


### PR DESCRIPTION
## Problem

`CompositionEndpointBuilder.Build()` constructs a per-request `composer` lambda that closes over that request's `argumentsByComponent`. The first request also builds the endpoint filter pipeline (in `BuildCompositionRequestFilterDelegatePipeline`), and its innermost delegate closes over that first composer. Subsequent requests find `cachedPipeline` non-null and reuse it, so they re-run the first request's composer with the first request's bound arguments.

The effect: every contract-less handler sees the **first** request's route values and body.

Reproducer (the new regression test boils this down):

- `GET /echo/1` then `GET /echo/2` -> both responses contain `Id: 1`.
- `POST /cart/addproduct/{orderId}` with different `orderId`s and different body `quantity`s -> all writes land on the first `orderId` with the first `quantity`.

## Fix

Stash the per-request composer in `HttpContext.Items` and read it back inside the cached pipeline's innermost delegate. The filter pipeline itself stays cached and purely structural; only the composer varies per request.

- `CompositionEndpointBuilder.cs`: add `CurrentComposerKey`, set `context.Items[CurrentComposerKey] = composer` before invoking the pipeline, drop `composer` from `BuildAndCacheEndpointFilterDelegatePipeline` call.
- `CompositionEndpointBuilder.EndpointFilters.cs`: drop the `composer` parameter from `BuildAndCacheEndpointFilterDelegatePipeline` and propagate the change down.
- `CompositionEndpointBuilder.CompositionFilters.cs`: drop the `composer` parameter; the innermost `filteredInvocation` now reads it from `HttpContext.Items[CurrentComposerKey]`.

## Regression test

`Per_request_arguments_are_not_shared.Two_sequential_requests_each_get_their_own_route_value` registers a contract-less handler that echoes its `int id` route param, fires `GET /echo/1` then `GET /echo/2`, and asserts each response carries its own id. Fails before the fix (returns `1` twice), passes after.

Verified end-to-end against a real .NET 10 gateway that uses the source-generated contract-less wrappers: route binding *and* `[FromBody]` are now per-request as expected.