### PR TITLE
Backport to 4.3 — Fix per-request composer leaked into cached endpoint pipeline (#1040)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,15 @@ The HTTP response should be a JSON result containing the properties and values d
 
 In this brief sample, the view model instance returned by `GetComposedResponseModel()` is a C# `dynamic` object. `dynamic` objects are handy because they allow request handlers to be entirely independent of each other; they share nothing. ServiceComposer supports using strongly typed view models if they are preferred. They have the advantages of strong typing and compiler checks and the disadvantages of a bit of coupling. Refer to the [view model factory documentation](docs/view-model-factory) for more information.
 
-## Documentation and supported platforms
+## Documentation, supported platforms, and supported versions
 
 ServiceComposer is available for the following platforms:
 
 - ASP.NET Core on .NET 8: [documentation is available in the docs folder](docs)
 
+> [!IMPORTANT]
+> Only the last two major releases are supported. Only the latest minor of every supported major is supported. That implies that bugfixes will be backported only to the most recent minor of every affected support major version.
+ 
 ## Philosophy
 
 ### Service Boundaries

--- a/src/ServiceComposer.AspNetCore.Tests/CompositionHandlers/Per_request_arguments_are_not_shared.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/CompositionHandlers/Per_request_arguments_are_not_shared.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using ServiceComposer.AspNetCore.Testing;
+using Xunit;
+
+namespace ServiceComposer.AspNetCore.Tests.CompositionHandlers
+{
+    // Regression test: the cached endpoint filter pipeline used to capture
+    // the first request's bound arguments and reuse them on every subsequent
+    // request. A second call to the same endpoint with a different route
+    // value would see the first request's value.
+    public class Per_request_arguments_are_not_shared
+    {
+        [CompositionHandler]
+        public class EchoIdHandler(IHttpContextAccessor httpContextAccessor)
+        {
+            [HttpGet("/echo/{id}")]
+            public Task Echo(int id)
+            {
+                var vm = httpContextAccessor.HttpContext!.Request.GetComposedResponseModel();
+                vm.Id = id;
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task Two_sequential_requests_each_get_their_own_route_value()
+        {
+            var client = new SelfContainedWebApplicationFactoryWithWebHost<Dummy>
+            (
+                configureServices: services =>
+                {
+                    services.AddViewModelComposition(options =>
+                    {
+                        options.AssemblyScanner.Disable();
+                        options.RegisterCompositionHandler<EchoIdHandler>();
+                        options.RegisterCompositionHandler<Generated.Per_request_arguments_are_not_shared_EchoIdHandler_Echo_int_id>();
+                    });
+                    services.AddRouting();
+                    services.AddControllers();
+                    services.AddHttpContextAccessor();
+                },
+                configure: app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(builder => builder.MapCompositionHandlers());
+                }
+            ).CreateClient();
+
+            client.DefaultRequestHeaders.Add("Accept-Casing", "casing/pascal");
+
+            var first = await client.GetAsync("/echo/1");
+            var second = await client.GetAsync("/echo/2");
+
+            Assert.True(first.IsSuccessStatusCode);
+            Assert.True(second.IsSuccessStatusCode);
+
+            var firstId = JObject.Parse(await first.Content.ReadAsStringAsync())
+                .SelectToken("Id")?.Value<int>();
+            var secondId = JObject.Parse(await second.Content.ReadAsStringAsync())
+                .SelectToken("Id")?.Value<int>();
+
+            Assert.Equal(1, firstId);
+            Assert.Equal(2, secondId);
+        }
+    }
+}

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.CompositionFilters.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.CompositionFilters.cs
@@ -9,7 +9,7 @@ namespace ServiceComposer.AspNetCore;
 
 partial class CompositionEndpointBuilder
 {
-   CompositionRequestFilterDelegate BuildCompositionRequestFilterDelegatePipeline(RequestDelegate composer, IServiceProvider serviceProvider)
+   CompositionRequestFilterDelegate BuildCompositionRequestFilterDelegatePipeline(IServiceProvider serviceProvider)
     {
         List<Func<CompositionRequestFilterFactoryContext, CompositionRequestFilterDelegate, CompositionRequestFilterDelegate>> compositionRequestFilterFactories = [];
         var compositionRequestFilters = Metadata
@@ -24,14 +24,17 @@ partial class CompositionEndpointBuilder
                 compositionRequestFilters.Add(typeBasedCompositionFilter);
             }
         }
-        
+
         compositionRequestFilters.ForEach(filter =>
         {
             compositionRequestFilterFactories.Add((factoryContext, next) => (context) => filter.InvokeAsync(context, next));
         });
 
+        // The composer is per-request: read it back from HttpContext.Items
+        // here so the cached pipeline does not close over a stale composer.
         CompositionRequestFilterDelegate filteredInvocation = async context =>
         {
+            var composer = (RequestDelegate)context.HttpContext.Items[CurrentComposerKey]!;
             await composer(context.HttpContext);
             var viewModel = context.HttpContext.Request.GetComposedResponseModel();
 

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.EndpointFilters.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.EndpointFilters.cs
@@ -8,11 +8,11 @@ namespace ServiceComposer.AspNetCore;
 partial class CompositionEndpointBuilder
 {
     static readonly object buildAndCacheEndpointFilterDelegatePipelineSyncLock = new ();
-    EndpointFilterDelegate BuildAndCacheEndpointFilterDelegatePipeline(RequestDelegate composer, IServiceProvider serviceProvider)
+    EndpointFilterDelegate BuildAndCacheEndpointFilterDelegatePipeline(IServiceProvider serviceProvider)
     {
         lock (buildAndCacheEndpointFilterDelegatePipelineSyncLock)
         {
-            var compositionFiltersPipeline = BuildCompositionRequestFilterDelegatePipeline(composer, serviceProvider);
+            var compositionFiltersPipeline = BuildCompositionRequestFilterDelegatePipeline(serviceProvider);
             
             var factoryContext = new EndpointFilterFactoryContext
             {

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointBuilder.cs
@@ -13,6 +13,14 @@ namespace ServiceComposer.AspNetCore
 {
     partial class CompositionEndpointBuilder : EndpointBuilder
     {
+        // The cached endpoint filter pipeline is built once per endpoint. The
+        // composer that runs at the bottom of the pipeline is per-request, so
+        // we cannot capture it in the cached delegate's closure (the cached
+        // delegate would replay the first request's bound arguments forever).
+        // Stash the per-request composer in HttpContext.Items under this key
+        // and have the innermost pipeline delegate read it back from there.
+        internal const string CurrentComposerKey = "__ServiceComposer.CurrentComposer";
+
         readonly Dictionary<ResponseCasing, JsonSerializerOptions> casingToSettingsMappings = new();
         readonly RoutePattern routePattern;
         readonly ResponseCasing defaultResponseCasing;
@@ -116,7 +124,11 @@ namespace ServiceComposer.AspNetCore
                     );
                     await CompositionHandler.HandleComposableRequest(composerHttpContext, compositionContext, componentsTypes);
                 };
-                var pipeline = cachedPipeline ?? BuildAndCacheEndpointFilterDelegatePipeline(composer, context.RequestServices);
+                // The cached pipeline reads the composer back from HttpContext.Items, so the
+                // per-request composer (and its captured argumentsByComponent) is the one
+                // that runs - not whichever composer happened to be the first one built.
+                context.Items[CurrentComposerKey] = composer;
+                var pipeline = cachedPipeline ?? BuildAndCacheEndpointFilterDelegatePipeline(context.RequestServices);
                 
                 // TODO use source generators
                 //   When we'll have convention-based handlers this could be


### PR DESCRIPTION
- Backport #1040 to release 4.3