### PR TITLE
Fix endpoint filters running more than once (backport to release-4.3)

### DIFF
--- a/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
+++ b/src/ServiceComposer.AspNetCore.Tests/When_using_endpoint_filters.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -196,6 +197,35 @@ namespace ServiceComposer.AspNetCore.Tests
             var contentString = await response.Content.ReadAsStringAsync();
             dynamic responseBody = JObject.Parse(contentString);
             Assert.Equal(expectedComposedRequestId, (string)responseBody.RequestId);
+        }
+
+        // Regression test for https://github.com/ServiceComposer/ServiceComposer.AspNetCore/issues/1063
+        // CompositionEndpointDataSource.Endpoints is a property that ASP.NET Core's routing
+        // infrastructure can, and does, enumerate more than once during startup and routing setup.
+        // AddEndpointFilter(...) is implemented as an endpoint convention that appends a filter
+        // factory, so re-applying conventions on every enumeration stacked the same filter factory
+        // onto the same, reused endpoint builder, resulting in the filter running more than once
+        // per request.
+        [Fact]
+        public void Should_apply_each_convention_only_once_even_when_endpoints_are_enumerated_multiple_times()
+        {
+            var dataSource = new CompositionEndpointDataSource();
+            var builder = new CompositionEndpointBuilder(
+                RoutePatternFactory.Parse("/some-route"),
+                Array.Empty<Type>(),
+                0,
+                ResponseCasing.PascalCase,
+                useOutputFormatters: false);
+            dataSource.AddEndpointBuilder(builder);
+
+            var conventionInvocationCount = 0;
+            dataSource.Add(_ => conventionInvocationCount++);
+
+            _ = dataSource.Endpoints;
+            _ = dataSource.Endpoints;
+            _ = dataSource.Endpoints;
+
+            Assert.Equal(1, conventionInvocationCount);
         }
     }
 }

--- a/src/ServiceComposer.AspNetCore/CompositionEndpointDataSource.cs
+++ b/src/ServiceComposer.AspNetCore/CompositionEndpointDataSource.cs
@@ -11,8 +11,10 @@ namespace ServiceComposer.AspNetCore
 {
     class CompositionEndpointDataSource : EndpointDataSource, IEndpointConventionBuilder
     {
+        readonly object endpointsBuildLock = new();
         readonly List<Action<EndpointBuilder>> conventions = [];
         readonly List<CompositionEndpointBuilder> _endpointBuilders = [];
+        IReadOnlyList<Endpoint> cachedEndpoints;
 
         public void AddEndpointBuilder(CompositionEndpointBuilder endpointBuilder)
         {
@@ -24,16 +26,38 @@ namespace ServiceComposer.AspNetCore
             return NullChangeToken.Singleton;
         }
 
-        public override IReadOnlyList<Endpoint> Endpoints => _endpointBuilders
-            .OrderBy(builder => builder.Order)
-            .Select(builder =>
+        // ASP.NET Core's routing infrastructure can, and does, enumerate an
+        // EndpointDataSource's Endpoints more than once during startup and
+        // routing setup. Since GetChangeToken() above never signals a change,
+        // there's never a reason to rebuild: conventions (e.g. AddEndpointFilter)
+        // must be applied to each endpoint builder exactly once, otherwise
+        // conventions that mutate state - like appending an endpoint filter
+        // factory - get re-applied on every enumeration, stacking duplicates
+        // onto the same, reused CompositionEndpointBuilder instances.
+        public override IReadOnlyList<Endpoint> Endpoints
+        {
+            get
             {
-                foreach (var convention in conventions)
+                if (cachedEndpoints == null)
                 {
-                    convention(builder);
+                    lock (endpointsBuildLock)
+                    {
+                        cachedEndpoints ??= _endpointBuilders
+                            .OrderBy(builder => builder.Order)
+                            .Select(builder =>
+                            {
+                                foreach (var convention in conventions)
+                                {
+                                    convention(builder);
+                                }
+                                return builder.Build();
+                            }).ToArray();
+                    }
                 }
-                return builder.Build();
-            }).ToArray();
+
+                return cachedEndpoints;
+            }
+        }
 
         public void Add(Action<EndpointBuilder> convention)
         {


### PR DESCRIPTION
## Summary

Backport of #1064 (fix for #1063) to `release-4.3`.

- `CompositionEndpointDataSource.Endpoints` re-applied every stored endpoint convention to the same, reused `CompositionEndpointBuilder` instances on **every** read of the property. ASP.NET Core's routing infrastructure can (and does) enumerate an `EndpointDataSource`'s `Endpoints` more than once during startup/routing setup.
- Because `AddEndpointFilter(...)` is implemented as a convention that appends a filter factory to the builder, each extra enumeration re-appended the same filter factory to the same builder, stacking duplicate entries in the filter pipeline and causing filters to execute more than once per request.
- Since `GetChangeToken()` always returns `NullChangeToken.Singleton` (the endpoint set never changes after registration), there's never a reason to rebuild. `Endpoints` now builds the endpoint array lazily once and caches it, so conventions are applied to each builder exactly once regardless of how many times the property is read.

Cherry-picked cleanly from master commit 6a0f4ea, no conflicts. Verified it builds and the test suite passes on this branch's net8.0 target.

## Test plan
- [x] Cherry-pick applied without conflicts
- [x] Includes the regression test added on master
- [x] `dotnet build` and `dotnet test` pass on release-4.3 (net8.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)